### PR TITLE
Use jinja templates

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -36,6 +36,7 @@ requirements:
     - pyyaml
     - esmpy
     - cfunits-python
+    - jinja2
 
 about:
   home: http://github.com/csdms/pymt

--- a/pymt/framework/bmi_docstring.py
+++ b/pymt/framework/bmi_docstring.py
@@ -8,9 +8,9 @@ from .bmi_metadata import load_bmi_metadata
 
 
 _DOCSTRING = u"""
-Basic Model Interface for {name}.
+Basic Model Interface for {{ name }}.
 
-{{desc}}
+{{ desc|trim|wordwrap(70) }}
 
 author: {{author}}
 version: {{version}}
@@ -38,13 +38,27 @@ Examples
 """.strip()
 
 
-def bmi_docstring(name):
+def bmi_docstring(name, author=None, version=None, license=None, doi=None,
+                  url=None, parameters=None):
     """Build the docstring for a BMI model.
 
     Parameters
     ----------
     name : str
         Name of a BMI component.
+    author : str, optional
+        Name of author or authors.
+    version : str, optional
+        Version string for the component.
+    license : str, optional
+        Name of the license of the component.
+    doi : str, optional
+        A DOI for the component.
+    url : str, optional
+        URL of the component's location on the internet.
+    parameters : iterable, optional
+        List of input parameters for the component. Each parameter object
+        must have attributes for name, type, value, units, and desc.
 
     Returns
     -------
@@ -52,15 +66,21 @@ def bmi_docstring(name):
         The docstring.
     """
     meta = load_bmi_metadata(name)
-    desc = '\n'.join(textwrap.wrap(meta['info'].summary))
-    
-    params = meta['defaults'].values()
-    params.sort(key=lambda p: p.name)
+
+    author = author or meta['info'].author
+    version = version or meta['info'].version
+    license = license or meta['info'].license
+    doi = doi or meta['info'].doi
+    url = url or meta['info'].url
+
+    parameters = parameters or meta['defaults'].values()
+    parameters.sort(key=lambda p: p.name)
 
     env = jinja2.Environment(loader=jinja2.DictLoader({'docstring': _DOCSTRING}))
     return env.get_template('docstring').render(
-        desc=desc, name=name,
-        parameters=params,
+        desc=meta['info'].summary,
+        name=name,
+        parameters=parameters,
         author=meta['info'].author,
         version=meta['info'].version,
         license=meta['info'].license,

--- a/pymt/framework/bmi_docstring.py
+++ b/pymt/framework/bmi_docstring.py
@@ -10,13 +10,13 @@ from .bmi_metadata import load_bmi_metadata
 _DOCSTRING = u"""
 Basic Model Interface for {{ name }}.
 
-{{ desc|trim|wordwrap(70) }}
+{{ desc|trim|wordwrap(70) if desc }}
 
-author: {{author}}
-version: {{version}}
-license: {{license}}
-DOI: {{doi}}
-URL: {{url}}
+Author: {{ author }}
+Version: {{ version }}
+License: {{ license }}
+DOI: {{ doi }}
+URL: {{ url }}
 {% if parameters %}
 Parameters
 ----------
@@ -39,7 +39,7 @@ Examples
 
 
 def bmi_docstring(name, author=None, version=None, license=None, doi=None,
-                  url=None, parameters=None):
+                  url=None, parameters=None, summary=None):
     """Build the docstring for a BMI model.
 
     Parameters
@@ -72,17 +72,17 @@ def bmi_docstring(name, author=None, version=None, license=None, doi=None,
     license = license or meta['info'].license
     doi = doi or meta['info'].doi
     url = url or meta['info'].url
-
+    summary = summary or meta['info'].summary
     parameters = parameters or meta['defaults'].values()
 
     env = jinja2.Environment(loader=jinja2.DictLoader({'docstring': _DOCSTRING}))
     return env.get_template('docstring').render(
-        desc=meta['info'].summary,
+        desc=summary,
         name=name,
         parameters=parameters,
-        author=meta['info'].author,
-        version=meta['info'].version,
-        license=meta['info'].license,
-        doi=meta['info'].doi,
-        url=meta['info'].url,
+        author=author,
+        version=version,
+        license=license,
+        doi=doi,
+        url=url,
     )

--- a/pymt/framework/bmi_docstring.py
+++ b/pymt/framework/bmi_docstring.py
@@ -2,28 +2,34 @@
 import os
 import textwrap
 
+import jinja2
+
 from .bmi_metadata import load_bmi_metadata
 
 
 _DOCSTRING = u"""
-Basic Modeling Interface for {name}.
+Basic Model Interface for {name}.
 
-{desc}
+{{desc}}
 
-author: {author}
-version: {version}
-license: {license}
-DOI: {doi}
-URL: {url}
-
+author: {{author}}
+version: {{version}}
+license: {{license}}
+DOI: {{doi}}
+URL: {{url}}
+{% if parameters %}
 Parameters
 ----------
-{parameters}
+{% for param in parameters -%}
+{{param.name}} : {{param.type}}, optional
+    {{ "%s [default=%s %s]"|format(param.desc, param.value, param.units)|trim|wordwrap(70)|indent(4) }}
+{% endfor %}
+{% endif -%}
 
 Examples
 --------
->>> from pymt.components import {name}
->>> model = {name}()
+>>> from pymt.components import {{name}}
+>>> model = {{name}}()
 >>> (fname, initdir) = model.setup()
 >>> model.initialize(fname, dir=initdir)
 >>> for _ in xrange(10):
@@ -83,9 +89,14 @@ def bmi_docstring(name):
     meta = load_bmi_metadata(name)
     desc = '\n'.join(textwrap.wrap(meta['info'].summary))
     
-    return _DOCSTRING.format(
+    params = meta['defaults'].values()
+    params.sort(key=lambda p: p.name)
+
+    env = jinja2.Environment(loader=jinja2.DictLoader({'docstring': _DOCSTRING}))
+    return env.get_template('docstring').render(
         desc=desc, name=name,
-        parameters=build_parameters_section(meta['defaults']),
+        parameters=params,
+        # parameters=build_parameters_section(meta['defaults']),
         author=meta['info'].author,
         version=meta['info'].version,
         license=meta['info'].license,

--- a/pymt/framework/bmi_docstring.py
+++ b/pymt/framework/bmi_docstring.py
@@ -20,7 +20,7 @@ URL: {{url}}
 {% if parameters %}
 Parameters
 ----------
-{% for param in parameters -%}
+{% for param in parameters|sort(attribute='name') -%}
 {{param.name}} : {{param.type}}, optional
     {{ "%s [default=%s %s]"|format(param.desc, param.value, param.units)|trim|wordwrap(70)|indent(4) }}
 {% endfor %}
@@ -74,7 +74,6 @@ def bmi_docstring(name, author=None, version=None, license=None, doi=None,
     url = url or meta['info'].url
 
     parameters = parameters or meta['defaults'].values()
-    parameters.sort(key=lambda p: p.name)
 
     env = jinja2.Environment(loader=jinja2.DictLoader({'docstring': _DOCSTRING}))
     return env.get_template('docstring').render(

--- a/pymt/framework/bmi_docstring.py
+++ b/pymt/framework/bmi_docstring.py
@@ -4,7 +4,7 @@ import textwrap
 
 import jinja2
 
-from .bmi_metadata import load_bmi_metadata
+from .bmi_metadata import load_bmi_metadata, ModelInfo
 
 
 _DOCSTRING = u"""
@@ -64,16 +64,32 @@ def bmi_docstring(name, author=None, version=None, license=None, doi=None,
     -------
     str
         The docstring.
-    """
-    meta = load_bmi_metadata(name)
 
-    author = author or meta['info'].author
-    version = version or meta['info'].version
-    license = license or meta['info'].license
-    doi = doi or meta['info'].doi
-    url = url or meta['info'].url
-    summary = summary or meta['info'].summary
-    parameters = parameters or meta['defaults'].values()
+    Examples
+    --------
+    >>> from pymt.framework.bmi_docstring import bmi_docstring
+    >>> print bmi_docstring('Model', author='Walt Disney') #doctest: +ELLIPSIS
+    Basic Model Interface for Model.
+    ...
+    """
+    try:
+        meta = load_bmi_metadata(name)
+    except IOError:
+        info = ModelInfo(name=name, author=author, version=version,
+                         license=license, doi=doi, url=url, summary=summary)
+        defaults = []
+    else:
+        info = meta['info']
+        defaults = meta['defaults'].values()
+
+    author = author or info.author
+    version = version or info.version
+    license = license or info.license
+    doi = doi or info.doi
+    url = url or info.url
+    summary = summary or info.summary
+    # parameters = parameters or meta['defaults'].values()
+    parameters = parameters or defaults
 
     env = jinja2.Environment(loader=jinja2.DictLoader({'docstring': _DOCSTRING}))
     return env.get_template('docstring').render(

--- a/pymt/framework/bmi_docstring.py
+++ b/pymt/framework/bmi_docstring.py
@@ -38,41 +38,6 @@ Examples
 """.strip()
 
 
-_PARAM_DECL = "{name} : {type}, optional"
-_PARAM_DESC = "{desc} [default={default} {units}]."
-
-
-def build_parameters_section(parameters):
-    """Build the paramters section of the docstring for a BMI model.
-
-    Parameters
-    ----------
-    parameters : dict
-        Parameters names and descriptions.
-
-    Returns
-    -------
-    str
-        The paramters section.
-    """
-    params = parameters.values()
-    params.sort(key=lambda p: p.name)
-
-    docstrings = []
-    for param in params:
-        decl = _PARAM_DECL.format(name=param.name, type=param.type)
-        desc = _PARAM_DESC.format(desc=param.desc, default=param.value,
-                                  units=param.units)
-
-        docstrings.extend(
-            textwrap.wrap(decl, subsequent_indent=' ' * (decl.find(':') + 3)))
-        docstrings.extend(
-            textwrap.wrap(desc, initial_indent=' ' * 4,
-                          subsequent_indent=' ' * 4))
-
-    return os.linesep.join(docstrings)
-
-
 def bmi_docstring(name):
     """Build the docstring for a BMI model.
 
@@ -96,7 +61,6 @@ def bmi_docstring(name):
     return env.get_template('docstring').render(
         desc=desc, name=name,
         parameters=params,
-        # parameters=build_parameters_section(meta['defaults']),
         author=meta['info'].author,
         version=meta['info'].version,
         license=meta['info'].license,

--- a/pymt/framework/tests/test_bmi_docstring.py
+++ b/pymt/framework/tests/test_bmi_docstring.py
@@ -1,0 +1,55 @@
+from nose.tools import assert_equal
+
+from pymt.framework.bmi_docstring import bmi_docstring
+
+DOCSTRING = u"""Basic Model Interface for Model.
+
+
+
+Author: None
+Version: None
+License: None
+DOI: None
+URL: None
+Examples
+--------
+>>> from pymt.components import Model
+>>> model = Model()
+>>> (fname, initdir) = model.setup()
+>>> model.initialize(fname, dir=initdir)
+>>> for _ in xrange(10):
+...     model.update()
+>>> model.finalize()
+""".strip()
+
+
+def test_empty_docstring():
+    docstring = bmi_docstring('Model')
+    assert_equal(docstring, DOCSTRING)
+
+
+def test_full_docstring():
+    docstring = bmi_docstring('DirtyHarry', author='Clint Eastwood',
+                              summary='The Good, The Bad, and the Ugly',
+                              version='0.1', license='To kill',
+                              doi='1977.12.23', url='welldoyapunk.org')
+    assert_equal(docstring, """
+Basic Model Interface for DirtyHarry.
+
+The Good, The Bad, and the Ugly
+
+Author: Clint Eastwood
+Version: 0.1
+License: To kill
+DOI: 1977.12.23
+URL: welldoyapunk.org
+Examples
+--------
+>>> from pymt.components import DirtyHarry
+>>> model = DirtyHarry()
+>>> (fname, initdir) = model.setup()
+>>> model.initialize(fname, dir=initdir)
+>>> for _ in xrange(10):
+...     model.update()
+>>> model.finalize()
+""".strip())

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Shapely>=1.3
 netcdf4
 pyyaml
 numpydoc
+jinja2


### PR DESCRIPTION
The pull request uses jinja2 templates to generate docstrings for BMI-wrapped PyMT components.