### PR TITLE
Add setter for time units

### DIFF
--- a/pymt/framework/bmi_bridge.py
+++ b/pymt/framework/bmi_bridge.py
@@ -351,6 +351,7 @@ class BmiCap(BmiTimeInterpolator, SetupMixIn):
         self._initialized = False
         self._grid = dict()
         self._var = dict()
+        self._time_units = None
         super(BmiCap, self).__init__()
 
     @property
@@ -544,7 +545,12 @@ class BmiCap(BmiTimeInterpolator, SetupMixIn):
 
     @property
     def time_units(self):
-        return self.get_time_units()
+        return self._time_units or self.get_time_units()
+        # return self.get_time_units()
+
+    @time_units.setter
+    def time_units(self, new_units):
+        self._time_units = new_units
 
     def get_time_units(self):
         return bmi_call(self.bmi.get_time_units)
@@ -571,10 +577,12 @@ class BmiCap(BmiTimeInterpolator, SetupMixIn):
 
     def time_in(self, time, units):
         if units is None:
-            return time
+            units = self.time_units
+            # return time
 
         try:
             units_str = self.get_time_units()
+            # units_str = self.time_units
         except (AttributeError, NotImplementedError):
             pass
         else:
@@ -591,7 +599,8 @@ class BmiCap(BmiTimeInterpolator, SetupMixIn):
             return time
 
         try:
-            units_str = self.get_time_units()
+            # units_str = self.get_time_units()
+            units_str = self.time_units
         except (AttributeError, NotImplementedError):
             pass
         else:

--- a/pymt/framework/tests/test_bmi_time_units.py
+++ b/pymt/framework/tests/test_bmi_time_units.py
@@ -25,6 +25,7 @@ class Bmi(_BmiCap):
 
 
 def test_time_wrap():
+    """Test wrapping BMI time methods."""
     bmi = Bmi()
 
     assert_equal(bmi.get_time_units(), 'h')
@@ -36,6 +37,7 @@ def test_time_wrap():
 
 
 def test_time_conversion():
+    """Test unit conversion through units keyword."""
     bmi = Bmi()
 
     assert_equal(bmi.get_start_time(units='h'), 1.)
@@ -46,10 +48,12 @@ def test_time_conversion():
 
 
 def test_change_time_units():
+    """Test changing a component's time units."""
     bmi = Bmi()
 
     assert_equal(bmi.time_units, 'h')
     bmi.time_units = 'min'
+    assert_equal(bmi.time_units, 'min')
 
     assert_equal(bmi.get_start_time(), 60.)
     assert_equal(bmi.get_current_time(), 630.)

--- a/pymt/framework/tests/test_bmi_time_units.py
+++ b/pymt/framework/tests/test_bmi_time_units.py
@@ -1,0 +1,60 @@
+from nose.tools import assert_equal
+
+from pymt.framework.bmi_bridge import _BmiCap
+
+
+class SimpleTimeBmi():
+    def get_time_units(self):
+        return 0, 'h'
+
+    def get_start_time(self):
+        return 0, 1.
+
+    def get_current_time(self):
+        return 0, 10.5
+
+    def get_end_time(self):
+        return 0, 72
+
+    def get_time_step(self):
+        return 0, 0.25
+
+
+class Bmi(_BmiCap):
+    _cls = SimpleTimeBmi
+
+
+def test_time_wrap():
+    bmi = Bmi()
+
+    assert_equal(bmi.get_time_units(), 'h')
+    assert_equal(bmi.get_start_time(), 1.)
+    assert_equal(bmi.get_current_time(), 10.5)
+    assert_equal(bmi.get_end_time(), 72.)
+    assert_equal(bmi.get_time_step(), .25)
+    assert_equal(bmi.time_units, 'h')
+
+
+def test_time_conversion():
+    bmi = Bmi()
+
+    assert_equal(bmi.get_start_time(units='h'), 1.)
+
+    assert_equal(bmi.get_start_time(units='min'), 60.)
+    assert_equal(bmi.get_current_time(units='min'), 630.)
+    assert_equal(bmi.get_end_time(units='d'), 3)
+
+
+def test_change_time_units():
+    bmi = Bmi()
+
+    assert_equal(bmi.time_units, 'h')
+    bmi.time_units = 'min'
+
+    assert_equal(bmi.get_start_time(), 60.)
+    assert_equal(bmi.get_current_time(), 630.)
+    assert_equal(bmi.get_end_time(), 72 * 60)
+
+    assert_equal(bmi.get_start_time(units='h'), 1.)
+    assert_equal(bmi.get_current_time(units='h'), 10.5)
+    assert_equal(bmi.get_end_time(units='h'), 72)


### PR DESCRIPTION
The pull request adds a setter method for `time_units`. This allows the user to set the time units for a component. For example,
```python
>>> bmi.time_units
'h'
>>> bmi.get_current_time()
72
>>> bmi.time_units = 'min'
>>> bmi.get_current_time()
3
```