### PR TITLE
Add cite as metadata

### DIFF
--- a/pymt/framework/bmi_docstring.py
+++ b/pymt/framework/bmi_docstring.py
@@ -17,6 +17,13 @@ Version: {{ version }}
 License: {{ license }}
 DOI: {{ doi }}
 URL: {{ url }}
+
+{% if cite_as -%}
+Cite as:
+{% for citation in cite_as %}
+{{ citation|trim|indent(width=4, indentfirst=True) }}
+{% endfor %}
+{%- endif %}
 {% if parameters %}
 Parameters
 ----------
@@ -39,7 +46,7 @@ Examples
 
 
 def bmi_docstring(name, author=None, version=None, license=None, doi=None,
-                  url=None, parameters=None, summary=None):
+                  url=None, parameters=None, summary=None, cite_as=None):
     """Build the docstring for a BMI model.
 
     Parameters
@@ -59,6 +66,8 @@ def bmi_docstring(name, author=None, version=None, license=None, doi=None,
     parameters : iterable, optional
         List of input parameters for the component. Each parameter object
         must have attributes for name, type, value, units, and desc.
+    cite_as : iterable of str, optional
+        List of citations for this component.
 
     Returns
     -------
@@ -76,7 +85,8 @@ def bmi_docstring(name, author=None, version=None, license=None, doi=None,
         meta = load_bmi_metadata(name)
     except IOError:
         info = ModelInfo(name=name, author=author, version=version,
-                         license=license, doi=doi, url=url, summary=summary)
+                         license=license, doi=doi, url=url, summary=summary,
+                         cite_as=cite_as)
         defaults = []
     else:
         info = meta['info']
@@ -88,7 +98,7 @@ def bmi_docstring(name, author=None, version=None, license=None, doi=None,
     doi = doi or info.doi
     url = url or info.url
     summary = summary or info.summary
-    # parameters = parameters or meta['defaults'].values()
+    cite_as = cite_as or info.cite_as
     parameters = parameters or defaults
 
     env = jinja2.Environment(loader=jinja2.DictLoader({'docstring': _DOCSTRING}))
@@ -101,4 +111,5 @@ def bmi_docstring(name, author=None, version=None, license=None, doi=None,
         license=license,
         doi=doi,
         url=url,
+        cite_as=cite_as,
     )

--- a/pymt/framework/bmi_metadata.py
+++ b/pymt/framework/bmi_metadata.py
@@ -13,7 +13,7 @@ from ..babel import query_config_var
 
 Parameter = namedtuple('Parameter', ('name', 'value', 'units', 'desc', 'type'))
 ModelInfo = namedtuple('ModelInfo', ('name', 'author', 'version', 'license',
-                                     'doi', 'url', 'summary'))
+                                     'doi', 'url', 'summary', 'cite_as'))
 ModelRun = namedtuple('ModelRun', ('config_file', ))
 ParameterSection = namedtuple('ParameterSection', ('title', 'members'))
 
@@ -195,6 +195,10 @@ def load_info_section(path):
     info = load_meta_section(path, 'info')
     api = load_meta_section(path, 'api')
 
+    info.setdefault('cite_as', [])
+    if isinstance(info['cite_as'], types.StringTypes):
+        info['cite_as'] = [info['cite_as']]
+
     return ModelInfo(
         name=api['name'],
         author=info.get('author', '-'),
@@ -203,6 +207,7 @@ def load_info_section(path):
         doi=info.get('doi', 'None'),
         url=info.get('url', 'None'),
         summary=info.get('summary', ''),
+        cite_as=info['cite_as'],
     )
 
 

--- a/pymt/framework/tests/test_bmi_docstring.py
+++ b/pymt/framework/tests/test_bmi_docstring.py
@@ -11,6 +11,8 @@ Version: None
 License: None
 DOI: None
 URL: None
+
+
 Examples
 --------
 >>> from pymt.components import Model
@@ -43,6 +45,44 @@ Version: 0.1
 License: To kill
 DOI: 1977.12.23
 URL: welldoyapunk.org
+
+
+Examples
+--------
+>>> from pymt.components import DirtyHarry
+>>> model = DirtyHarry()
+>>> (fname, initdir) = model.setup()
+>>> model.initialize(fname, dir=initdir)
+>>> for _ in xrange(10):
+...     model.update()
+>>> model.finalize()
+""".strip())
+
+
+def test_cite_as():
+    docstring = bmi_docstring('DirtyHarry', author='Clint Eastwood',
+                              summary='The Good, The Bad, and the Ugly',
+                              version='0.1', license='To kill',
+                              doi='1977.12.23', url='welldoyapunk.org',
+                              cite_as=['ref1', 'ref2'])
+
+    assert_equal(docstring, """
+Basic Model Interface for DirtyHarry.
+
+The Good, The Bad, and the Ugly
+
+Author: Clint Eastwood
+Version: 0.1
+License: To kill
+DOI: 1977.12.23
+URL: welldoyapunk.org
+
+Cite as:
+
+    ref1
+
+    ref2
+
 Examples
 --------
 >>> from pymt.components import DirtyHarry


### PR DESCRIPTION
This pull request adds a "cite_as" section to a component's *info* section of its BMI metadata. It also adds a "Cite as" section to its docstring that just lists the citations from the metadata file.