### PR TITLE
Fix absolute path for initdir

### DIFF
--- a/pymt/framework/bmi_bridge.py
+++ b/pymt/framework/bmi_bridge.py
@@ -401,7 +401,7 @@ class _BmiCap(object):
         #     self._initialized = True
 
         self._initdir = os.path.abspath(dir)
-        with cd(dir, create=False):
+        with cd(self.initdir, create=False):
             if bmi_call(self.bmi.initialize, fname or '') == 0:
                 self._initialized = True
 

--- a/pymt/framework/bmi_setup.py
+++ b/pymt/framework/bmi_setup.py
@@ -173,7 +173,7 @@ class SetupMixIn(object):
 
         copy_data_files(self.datadir, dir, **self._parameters)
         
-        return self._meta['run'].config_file, dir
+        return self._meta['run'].config_file, os.path.abspath(dir)
 
         # return dir, self._meta['run'].config_file
 


### PR DESCRIPTION
This PR fixes a bug where the relative path of the `initdir` was being used in `initialize`. The `setup` method now also returns the absolute path to the initdir (regardless what was passed as the `dir` keyword).