### PR TITLE
Allow multiple authors of components

### DIFF
--- a/pymt/framework/bmi_docstring.py
+++ b/pymt/framework/bmi_docstring.py
@@ -1,8 +1,10 @@
 #! /usr/bin/env python
 import os
 import textwrap
+import types
 
 import jinja2
+import six
 
 from .bmi_metadata import load_bmi_metadata, ModelInfo
 from ..babel import BabelConfigError
@@ -89,6 +91,9 @@ def bmi_docstring(name, author=None, version=None, license=None, doi=None,
     Basic Model Interface for Model.
     ...
     """
+    author = author or []
+    cite_as = cite_as or []
+
     try:
         meta = load_bmi_metadata(name)
     except (IOError, BabelConfigError):
@@ -109,6 +114,11 @@ def bmi_docstring(name, author=None, version=None, license=None, doi=None,
     summary = summary or info.summary
     cite_as = cite_as or info.cite_as
     parameters = parameters or defaults
+
+    if isinstance(author, types.StringTypes):
+        author = [author]
+    if isinstance(cite_as, types.StringTypes):
+        cite_as = [cite_as]
 
     env = jinja2.Environment(loader=jinja2.DictLoader({'docstring': _DOCSTRING}))
     return env.get_template('docstring').render(

--- a/pymt/framework/bmi_docstring.py
+++ b/pymt/framework/bmi_docstring.py
@@ -13,7 +13,11 @@ Basic Model Interface for {{ name }}.
 
 {{ desc|trim|wordwrap(70) if desc }}
 
-Author: {{ author }}
+{% if author -%}
+Author:
+{%- for name in author %}
+{{"- " + name|trim }}{% endfor %}
+{%- endif %}
 Version: {{ version }}
 License: {{ license }}
 DOI: {{ doi }}

--- a/pymt/framework/bmi_metadata.py
+++ b/pymt/framework/bmi_metadata.py
@@ -199,10 +199,13 @@ def load_info_section(path):
     info.setdefault('cite_as', [])
     if isinstance(info['cite_as'], types.StringTypes):
         info['cite_as'] = [info['cite_as']]
+    author = info.get('author', ['anonymous'])
+    if isinstance(author, types.StringTypes):
+        author = [author]
 
     return ModelInfo(
         name=api['name'],
-        author=info.get('author', '-'),
+        author=author,
         email=info.get('email', '-'),
         version=info.get('version', '-'),
         license=info.get('license', 'None'),

--- a/pymt/framework/tests/test_bmi_docstring.py
+++ b/pymt/framework/tests/test_bmi_docstring.py
@@ -6,7 +6,7 @@ DOCSTRING = u"""Basic Model Interface for Model.
 
 
 
-Author: None
+
 Version: None
 License: None
 DOI: None
@@ -40,7 +40,8 @@ Basic Model Interface for DirtyHarry.
 
 The Good, The Bad, and the Ugly
 
-Author: Clint Eastwood
+Author:
+- Clint Eastwood
 Version: 0.1
 License: To kill
 DOI: 1977.12.23
@@ -71,7 +72,8 @@ Basic Model Interface for DirtyHarry.
 
 The Good, The Bad, and the Ugly
 
-Author: Clint Eastwood
+Author:
+- Clint Eastwood
 Version: 0.1
 License: To kill
 DOI: 1977.12.23


### PR DESCRIPTION
This pull request reads a model's `info.yaml` file and parses the `author` field as either a string or a list of strings to represent multiple authors. The authors are listed in the docstring as one per line.