### PR TITLE
Allow legacy docstrings with numpy 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 env:
   global:
   - CONDA_PREFIX=$HOME/miniconda
-  - MINICONDA_URL_BASE="https://repo.continuum.io/miniconda/Miniconda3-latest"
+  - MINICONDA_URL_BASE="https://repo.continuum.io/miniconda/Miniconda2-latest"
   - TRAVIS_PYTHON_VERSION="2.7"
   - secure: KEm0QwqwPnYuwk1sZ9tjUXWD+ZqDXgJ2DL25Iv77s4KqXfDkrQ+Q2JkWRQgN9IWRpsQf1/SorIeZzCkCXy+GkErAqJDGk/EVnpzdLitZ1caZgKj2H7W3cMZ51qZh3UQrxwo+H9FW6PaltCezkOIk5Q/VdewlSYny7dqpoYjsc/o=
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - CONDA_PREFIX=$HOME/miniconda
   - MINICONDA_URL_BASE="https://repo.continuum.io/miniconda/Miniconda2-latest"
   - TRAVIS_PYTHON_VERSION="2.7"
-  - secure: KEm0QwqwPnYuwk1sZ9tjUXWD+ZqDXgJ2DL25Iv77s4KqXfDkrQ+Q2JkWRQgN9IWRpsQf1/SorIeZzCkCXy+GkErAqJDGk/EVnpzdLitZ1caZgKj2H7W3cMZ51qZh3UQrxwo+H9FW6PaltCezkOIk5Q/VdewlSYny7dqpoYjsc/o=
+  - secure: "N7EenUcspE/pyC1I+TVLowRIBKPylRC6Jlk/DP4u5GAqIkrLqeZPvTjrWBIMvCkZ2B2dPtUZ5IbbxRMTZCTOQxzlcOL4hbJyzsrRJsskya+Mg9oAFYrZJ6D77AZaQ8iwLgGsOBJsTCyBp9iTBiB3x3KZYUwaMPw3SScVrbNOgzk="
 sudo: false
 before_install:
 - |

--- a/pymt/__init__.py
+++ b/pymt/__init__.py
@@ -4,4 +4,7 @@ del get_versions
 
 # See https://github.com/numpy/numpy/blob/master/doc/release/1.14.0-notes.rst#many-changes-to-array-printing-disableable-with-the-new-legacy-printing-mode
 import numpy as np
-np.set_printoptions(legacy='1.13')
+try:
+    np.set_printoptions(legacy='1.13')
+except TypeError:
+    pass

--- a/pymt/__init__.py
+++ b/pymt/__init__.py
@@ -1,3 +1,7 @@
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
+
+# See https://github.com/numpy/numpy/blob/master/doc/release/1.14.0-notes.rst#many-changes-to-array-printing-disableable-with-the-new-legacy-printing-mode
+import numpy as np
+np.set_printoptions(legacy='1.13')

--- a/pymt/printers/nc/tests/test_ugrid_read.py
+++ b/pymt/printers/nc/tests/test_ugrid_read.py
@@ -3,7 +3,7 @@ import os
 from pymt.printers.nc.read import field_fromfile
 
 
-_BASE_URL_FOR_TEST_FILES = ('http://csdms.colorado.edu/thredds/fileServer'
+_BASE_URL_FOR_TEST_FILES = ('https://csdms.colorado.edu/thredds/fileServer'
                             '/benchmark/ugrid/')
 _TMP_DIR = 'tmp'
 


### PR DESCRIPTION
In numpy 1.14, an improvement was made which attempts to remove extra spaces from printed floats (see [release notes](https://github.com/numpy/numpy/blob/master/doc/release/1.14.0-notes.rst#many-changes-to-array-printing-disableable-with-the-new-legacy-printing-mode)). This wreaked havoc with docstring tests. Using `numpy.set_printoptions(legacy='1.13')` disables this new behavior.

Interestingly, for builds on Travis, the Miniconda3 installer caused problems when trying to install Python 2.7. This should work. Using the Miniconda2 installer solved the problem. We should keep an eye on this, though, as 2.7 is phased out.

Also, an unrelated problem -- last week OIT made csdms.colorado.edu accessible only by HTTPS, which caused the URL for the CSDMS THREDDS server used in tests to fail.