### PR TITLE
Add new-style plugins

### DIFF
--- a/pymt/__init__.py
+++ b/pymt/__init__.py
@@ -17,6 +17,6 @@ del np
 from .plugin import load_pymt_plugins
 
 
-plugins = load_pymt_plugins()
+plugins = load_pymt_plugins(include_old_style=True)
 
 del load_pymt_plugins

--- a/pymt/__init__.py
+++ b/pymt/__init__.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+import sys
+
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
@@ -8,3 +11,12 @@ try:
     np.set_printoptions(legacy='1.13')
 except TypeError:
     pass
+del np
+
+
+from .plugin import load_pymt_plugins
+
+
+plugins = load_pymt_plugins()
+
+del load_pymt_plugins

--- a/pymt/framework/bmi_bridge.py
+++ b/pymt/framework/bmi_bridge.py
@@ -555,6 +555,9 @@ class _BmiCap(object):
         bmi_call(self.bmi.get_grid_origin, grid, out)
         return out
 
+    def get_grid_number_of_nodes(self, grid):
+        return self.get_grid_size(grid)
+
     def get_grid_number_of_vertices(self, grid):
         return self.get_grid_nodes_per_face(grid).sum()
 
@@ -577,8 +580,7 @@ class _BmiCap(object):
 
     def get_grid_face_node_offset(self, grid, out=None):
         nodes_per_face = self.get_grid_nodes_per_face(grid, out=out)
-        np.cumsum(nodes_per_face, out=out)
-        return out
+        return np.cumsum(nodes_per_face, out=out)
 
     def get_grid_nodes_per_face(self, grid, out=None):
         if out is None:
@@ -696,7 +698,10 @@ class _BmiCap(object):
         return intent
 
     def get_var_location(self, name):
-        return 'node'
+        return self.get_var_grid_loc(name)
+
+    def get_var_grid_loc(self, name):
+        return bmi_call(self.bmi.get_var_location, name)
 
     def get_var_grid(self, name):
         return bmi_call(self.bmi.get_var_grid, name)

--- a/pymt/framework/bmi_ugrid.py
+++ b/pymt/framework/bmi_ugrid.py
@@ -34,7 +34,7 @@ def dataset_from_bmi_grid(bmi, grid_id):
 
 
 def dataset_from_bmi_scalar(bmi, grid_id):
-    rank = bmi.get_grid_rank(grid_id)
+    rank = bmi.get_grid_ndim(grid_id)
 
     if rank != 0:
         raise ValueError('scalar must be rank 0')
@@ -52,7 +52,7 @@ def dataset_from_bmi_scalar(bmi, grid_id):
 def dataset_from_bmi_uniform_rectilinear(bmi, grid_id):
     from landlab.graph import UniformRectilinearGraph
 
-    rank = bmi.get_grid_rank(grid_id)
+    rank = bmi.get_grid_ndim(grid_id)
     shape = bmi.get_grid_shape(grid_id)
     spacing = bmi.get_grid_spacing(grid_id)
     origin = bmi.get_grid_origin(grid_id)
@@ -88,7 +88,7 @@ def dataset_from_bmi_uniform_rectilinear(bmi, grid_id):
     for axis, name in enumerate(COORDINATE_NAMES[-rank:]):
         dataset = dataset.update({
             'node_' + name: xr.DataArray(
-                data=coords_at_node[axis].reshape(-1), dims=('n_node', ),
+                data=coords_at_node[axis].reshape(-1), dims=('node', ),
                 attrs={'standard_name': name, 'units': 'm'})
         })
 
@@ -98,13 +98,13 @@ def dataset_from_bmi_uniform_rectilinear(bmi, grid_id):
         dataset = dataset.update({
             'face_node_connectivity': xr.DataArray(
                 data=graph.nodes_at_patch.reshape((-1 ,)),
-                dims=('n_vertex', ),
+                dims=('vertex', ),
                 attrs={'standard_name': 'Face-node connectivity'})
         })
         dataset = dataset.update({
             'face_node_offset': xr.DataArray(
                 data=np.arange(1, graph.number_of_patches + 1, dtype=np.int32) * 4,
-                dims=('n_face', ),
+                dims=('face', ),
                 attrs={'standard_name': 'Offset to face-node connectivity'})
         })
 
@@ -112,7 +112,7 @@ def dataset_from_bmi_uniform_rectilinear(bmi, grid_id):
 
 
 def dataset_from_bmi_points(bmi, grid_id):
-    rank = bmi.get_grid_rank(grid_id)
+    rank = bmi.get_grid_ndim(grid_id)
     attrs=OrderedDict([
         ('cf_role', 'mesh_topology'),
         ('long_name', 'Topology data of 2D unstructured points'),
@@ -128,7 +128,7 @@ def dataset_from_bmi_points(bmi, grid_id):
         data=getattr(bmi, 'get_grid_' + dim_name)(grid_id)
         coord = xr.DataArray(
             data=data,
-            dims=('n_node', ),
+            dims=('node', ),
             attrs={'standard_name': dim_name, 'units': 'm'})
         coords['node_' + dim_name] = coord
 
@@ -138,7 +138,7 @@ def dataset_from_bmi_points(bmi, grid_id):
 
 
 def dataset_from_bmi_unstructured(bmi, grid_id):
-    rank = bmi.get_grid_rank(grid_id)
+    rank = bmi.get_grid_ndim(grid_id)
     attrs=OrderedDict([
         ('cf_role', 'mesh_topology'),
         ('long_name', 'Topology data of 2D unstructured points'),
@@ -154,7 +154,7 @@ def dataset_from_bmi_unstructured(bmi, grid_id):
         data=getattr(bmi, 'get_grid_' + dim_name)(grid_id)
         coord = xr.DataArray(
             data=data,
-            dims=('n_node', ),
+            dims=('node', ),
             attrs={'standard_name': dim_name, 'units': 'm'})
         coords['node_' + dim_name] = coord
 
@@ -163,13 +163,13 @@ def dataset_from_bmi_unstructured(bmi, grid_id):
     face_node_connectivity = xr.DataArray(
         data=bmi.get_grid_face_nodes(grid_id),
         # data=bmi.get_grid_face_node_connectivity(grid_id),
-        dims=('n_vertex', ),
+        dims=('vertex', ),
         attrs={'standard_name': 'Face-node connectivity'})
     ugrid.update({'face_node_connectivity': face_node_connectivity})
 
     face_node_offset = xr.DataArray(
         data=bmi.get_grid_face_node_offset(grid_id),
-        dims=('n_face', ),
+        dims=('face', ),
         attrs={'standard_name': 'Offset to face-node connectivity'})
     ugrid.update({'face_node_offset': face_node_offset})
 

--- a/pymt/framework/bmi_ugrid.py
+++ b/pymt/framework/bmi_ugrid.py
@@ -98,13 +98,13 @@ def dataset_from_bmi_uniform_rectilinear(bmi, grid_id):
         dataset = dataset.update({
             'face_node_connectivity': xr.DataArray(
                 data=graph.nodes_at_patch.reshape((-1 ,)),
-                dims=('n_vertices', ),
+                dims=('n_vertex', ),
                 attrs={'standard_name': 'Face-node connectivity'})
         })
         dataset = dataset.update({
             'face_node_offset': xr.DataArray(
                 data=np.arange(1, graph.number_of_patches + 1, dtype=np.int32) * 4,
-                dims=('n_faces', ),
+                dims=('n_face', ),
                 attrs={'standard_name': 'Offset to face-node connectivity'})
         })
 
@@ -163,13 +163,13 @@ def dataset_from_bmi_unstructured(bmi, grid_id):
     face_node_connectivity = xr.DataArray(
         data=bmi.get_grid_face_nodes(grid_id),
         # data=bmi.get_grid_face_node_connectivity(grid_id),
-        dims=('n_vertices', ),
+        dims=('n_vertex', ),
         attrs={'standard_name': 'Face-node connectivity'})
     ugrid.update({'face_node_connectivity': face_node_connectivity})
 
     face_node_offset = xr.DataArray(
         data=bmi.get_grid_face_node_offset(grid_id),
-        dims=('n_faces', ),
+        dims=('n_face', ),
         attrs={'standard_name': 'Offset to face-node connectivity'})
     ugrid.update({'face_node_offset': face_node_offset})
 

--- a/pymt/framework/bmi_ugrid.py
+++ b/pymt/framework/bmi_ugrid.py
@@ -161,7 +161,8 @@ def dataset_from_bmi_unstructured(bmi, grid_id):
     ugrid.update(coords)
 
     face_node_connectivity = xr.DataArray(
-        data=bmi.get_grid_face_node_connectivity(grid_id),
+        data=bmi.get_grid_face_nodes(grid_id),
+        # data=bmi.get_grid_face_node_connectivity(grid_id),
         dims=('n_vertices', ),
         attrs={'standard_name': 'Face-node connectivity'})
     ugrid.update({'face_node_connectivity': face_node_connectivity})

--- a/pymt/framework/tests/test_bmi_time_units.py
+++ b/pymt/framework/tests/test_bmi_time_units.py
@@ -5,19 +5,19 @@ from pymt.framework.bmi_bridge import _BmiCap
 
 class SimpleTimeBmi():
     def get_time_units(self):
-        return 0, 'h'
+        return 'h'
 
     def get_start_time(self):
-        return 0, 1.
+        return 1.
 
     def get_current_time(self):
-        return 0, 10.5
+        return 10.5
 
     def get_end_time(self):
-        return 0, 72
+        return 72
 
     def get_time_step(self):
-        return 0, 0.25
+        return 0.25
 
 
 class Bmi(_BmiCap):

--- a/pymt/plugin.py
+++ b/pymt/plugin.py
@@ -32,11 +32,14 @@ from __future__ import print_function
 __all__ = []
 
 import os
+import sys
 import logging
 import importlib
 from glob import glob
 
 import pkg_resources
+
+from scripting import success, error
 
 from .framework.bmi_bridge import bmi_factory
 from .babel import setup_babel_environ
@@ -169,10 +172,9 @@ def load_pymt_plugins():
         try:
             plugin = entry_point.load()
         except Exception as err:
-            print('unable to import: {0}'.format(entry_point.name),
-                  file=sys.stderr)
+            error(entry_point.name)
         else:
-            print('imported plugin: {0}'.format(entry_point.name))
+            success(entry_point.name)
             plugin = bmi_factory(plugin)
             setattr(plugins, entry_point.name, plugin)
 

--- a/pymt/plugin.py
+++ b/pymt/plugin.py
@@ -36,6 +36,8 @@ import logging
 import importlib
 from glob import glob
 
+import pkg_resources
+
 from .framework.bmi_bridge import bmi_factory
 from .babel import setup_babel_environ
 
@@ -155,3 +157,23 @@ def load_csdms_plugins():
     setup_babel_environ()
     entry_points = discover_csdms_plugins()
     return load_all_plugins(entry_points, callback=bmi_factory)
+
+
+def load_pymt_plugins():
+    class Plugins(object):
+        pass
+
+    plugins = Plugins()
+
+    for entry_point in pkg_resources.iter_entry_points(group='pymt.plugins'):
+        try:
+            plugin = entry_point.load()
+        except Exception as err:
+            print('unable to import: {0}'.format(entry_point.name),
+                  file=sys.stderr)
+        else:
+            print('imported plugin: {0}'.format(entry_point.name))
+            plugin = bmi_factory(plugin)
+            setattr(plugins, entry_point.name, plugin)
+
+    return plugins

--- a/pymt/plugin.py
+++ b/pymt/plugin.py
@@ -162,8 +162,9 @@ def load_csdms_plugins():
     return load_all_plugins(entry_points, callback=bmi_factory)
 
 
-def load_pymt_plugins():
+def load_pymt_plugins(include_old_style=False):
     class Plugins(object):
+        """PyMT BMI component plugins."""
         pass
 
     plugins = Plugins()
@@ -177,5 +178,11 @@ def load_pymt_plugins():
             success(entry_point.name)
             plugin = bmi_factory(plugin)
             setattr(plugins, entry_point.name, plugin)
+
+    if include_old_style:
+        for plugin in load_csdms_plugins():
+            if not hasattr(plugins, plugin.__name__):
+                success(plugin.__name__)
+                setattr(plugins, plugin.__name__, plugin)
 
     return plugins

--- a/pymt/utils/decorators.py
+++ b/pymt/utils/decorators.py
@@ -1,0 +1,62 @@
+#! /usr/bin/env python
+import os
+import warnings
+import textwrap
+from functools import wraps
+
+
+class cache_result_in_object(object):
+    def __init__(self, cache_as=None):
+        self._attr = cache_as
+
+    def __call__(self, func):
+        name = self._attr or '_' + func.__name__
+        @wraps(func)
+        def _wrapped(obj):
+            if not hasattr(obj, name):
+                setattr(obj, name, func(obj))
+            return getattr(obj, name)
+
+        return _wrapped
+
+
+class deprecated(object):
+
+    """Mark a function as deprecated."""
+
+    def __init__(self, use=None):
+        self._use = use
+
+    def __call__(self, func):
+        doc_lines = (func.__doc__ or "").split(os.linesep)
+
+        for lineno, line in enumerate(doc_lines):
+            if len(line.rstrip()) == 0:
+                break
+
+        head = doc_lines[:lineno]
+        body = doc_lines[lineno:]
+
+        head = textwrap.dedent(os.linesep.join(head))
+        body = textwrap.dedent(os.linesep.join(body))
+
+        doc_lines = [head, ".. note:: deprecated", ""]
+        if self._use is not None:
+            doc_lines.extend(
+                ["    Use :func:`{use}` instead.".format(use=self._use), ""])
+        doc_lines.append(body)
+
+        func.__doc__ = os.linesep.join(doc_lines)
+
+        @wraps(func)
+        def _wrapped(*args, **kwargs):
+            if func.__name__.startswith('_'):
+                pass
+            else:
+                warnings.warn(
+                    message="Call to deprecated function {name}.".format(
+                        name=func.__name__), )
+                    # category=DeprecationWarning)
+            return func(*args, **kwargs)
+
+        return _wrapped


### PR DESCRIPTION
This pull request adds a new method of discovering pymt plugins. Plugins are still found in the old way (that is, looking for a `csdms` package and loading BMI classes from there) and, as before, can be accessed through `pymt.components`. The new-style plugins are contained in `pymt.plugins`. The old-style plugins are also here but may be removed in the future.

BMI plugins are now registered in the component's setup.py file as a `pymt.plugin` entry point. The `model_metadata` package (as of version 0.3) provides some convenience functions for registering and installing these sorts of plugins.