### PR TITLE
Fix pytest fixture errors

### DIFF
--- a/pymt/component/tests/conftest.py
+++ b/pymt/component/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 
 
 @pytest.fixture(scope="session")
-def setup():
+def with_no_components():
     from pymt.framework.services import register_component_classes, del_services
 
     del_services()

--- a/pymt/component/tests/test_map_component.py
+++ b/pymt/component/tests/test_map_component.py
@@ -5,7 +5,7 @@ from pymt.component.component import Component
 from pymt.testing.assertions import assert_isfile_and_remove
 
 
-def test_print_events(setup):
+def test_print_events(with_no_components):
     air = Component.load(
         """
 name: air_port

--- a/pymt/component/tests/test_model.py
+++ b/pymt/component/tests/test_model.py
@@ -20,7 +20,7 @@ connectivity: []
 """
 
 
-def test_model_load(setup):
+def test_model_load(with_no_components):
     del_component_instances(["air_port"])
     with cd_temp() as _:
         os.mkdir("air")
@@ -29,7 +29,7 @@ def test_model_load(setup):
         assert_equal(model.components, ["air_port"])
 
 
-def test_model_from_file(setup):
+def test_model_from_file(with_no_components):
     del_component_instances(["air_port"])
     with cd_temp() as _:
         os.mkdir("air")
@@ -40,7 +40,7 @@ def test_model_from_file(setup):
         assert_equal(model.components, ["air_port"])
 
 
-def test_model_from_file_like(setup):
+def test_model_from_file_like(with_no_components):
     del_component_instances(["air_port"])
     with cd_temp() as _:
         os.mkdir("air")

--- a/pymt/component/tests/test_one_component.py
+++ b/pymt/component/tests/test_one_component.py
@@ -6,7 +6,7 @@ from pymt.testing.assertions import assert_isfile_and_remove
 from pymt.framework.services import del_component_instances
 
 
-def test_no_events(setup):
+def test_no_events(with_no_components):
     del_component_instances(["AirPort"])
 
     comp = Component("AirPort", uses=[], provides=[], events=[])
@@ -14,7 +14,7 @@ def test_no_events(setup):
     assert_equal(comp._port.current_time, 100.)
 
 
-def test_from_string(setup):
+def test_from_string(with_no_components):
     del_component_instances(["air_port"])
 
     contents = """
@@ -26,7 +26,7 @@ class: AirPort
     assert_equal(comp._port.current_time, 100.)
 
 
-def test_print_events(setup):
+def test_print_events(with_no_components):
     del_component_instances(["earth_port"])
 
     contents = """
@@ -53,7 +53,7 @@ print:
         assert_isfile_and_remove("earth_surface__density_%04d.vtu" % i)
 
 
-def test_rerun(setup):
+def test_rerun(with_no_components):
     del_component_instances(["AirPort"])
 
     comp = Component("AirPort", uses=[], provides=[], events=[])
@@ -64,7 +64,7 @@ def test_rerun(setup):
     assert_equal(comp._port.current_time, 100.)
 
 
-def test_rerun_with_print(setup):
+def test_rerun_with_print(with_no_components):
     del_component_instances(["earth_port"])
 
     contents = """

--- a/pymt/component/tests/test_recursive.py
+++ b/pymt/component/tests/test_recursive.py
@@ -6,7 +6,7 @@ from pymt.testing.assertions import assert_isfile_and_remove
 from pymt.framework.services import del_component_instances
 
 
-def test_no_events(setup):
+def test_no_events(with_no_components):
     del_component_instances(["air_port", "earth_port"])
 
     air = Component("AirPort", name="air_port", uses=[], provides=[], events=[])
@@ -21,7 +21,7 @@ def test_no_events(setup):
     assert_equal(earth._port.current_time, 100.)
 
 
-def test_print_events(setup):
+def test_print_events(with_no_components):
     air_init_string = """
 name: air_port
 class: AirPort

--- a/pymt/component/tests/test_two_components.py
+++ b/pymt/component/tests/test_two_components.py
@@ -6,7 +6,7 @@ from pymt.testing.assertions import assert_isfile_and_remove
 from pymt.framework.services import del_component_instances
 
 
-def test_no_events(setup):
+def test_no_events(with_no_components):
     del_component_instances(["air_port", "earth_port"])
 
     air = Component("AirPort", name="air_port", uses=[], provides=[], events=[])
@@ -20,7 +20,7 @@ def test_no_events(setup):
     assert_equal(air._port.current_time, 100.)
 
 
-def test_print_events(setup):
+def test_print_events(with_no_components):
     del_component_instances(["air_port", "earth_port"])
 
     air = Component.from_string(

--- a/pymt/framework/bmi_ugrid.py
+++ b/pymt/framework/bmi_ugrid.py
@@ -26,7 +26,7 @@ def dataset_from_bmi_grid(bmi, grid_id):
         grid = dataset_from_bmi_scalar(bmi, grid_id)
     elif grid_type.startswith("unstructured"):
         grid = dataset_from_bmi_unstructured(bmi, grid_id)
-    elif grid_type == 'vector':
+    elif grid_type == "vector":
         grid = dataset_from_bmi_vector(bmi, grid_id)
     else:
         raise ValueError("grid type not understood ({gtype})".format(gtype=grid_type))

--- a/pymt/framework/services.py
+++ b/pymt/framework/services.py
@@ -55,6 +55,12 @@ def register_component_class(name, if_exists="raise"):
 
     Examples
     --------
+    >>> from pymt.framework.services import (
+    ...     del_services,
+    ...     register_component_class,
+    ...     get_component_class
+    ... )
+
     >>> del_services()
     >>> register_component_class('pymt.testing.services.AirPort')
     >>> get_component_class('AirPort')
@@ -107,6 +113,12 @@ def register_component_instance(name, instance):
 
     Examples
     --------
+    >>> from pymt.framework.services import (
+    ...     del_services,
+    ...     register_component_class,
+    ...     get_component_instance
+    ... )
+
     >>> del_services()
     >>> from pymt.testing.services import AirPort
     >>> air_port = AirPort()
@@ -165,6 +177,13 @@ def instantiate_component(cls_name, instance_name):
 
     Examples
     --------
+    >>> from pymt.framework.services import (
+    ...     del_services,
+    ...     register_component_class,
+    ...     instantiate_component,
+    ...     get_component_instance
+    ... )
+
     >>> del_services()
     >>> register_component_class('pymt.testing.services.AirPort')
     >>> air_port = instantiate_component('AirPort', 'air_port')

--- a/pymt/portprinter/tests/conftest.py
+++ b/pymt/portprinter/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 
 
 @pytest.fixture(scope="session")
-def setup():
+def with_two_components():
     from pymt.framework.services import (
         register_component_classes,
         instantiate_component,

--- a/pymt/portprinter/tests/test_port_printer_queue.py
+++ b/pymt/portprinter/tests/test_port_printer_queue.py
@@ -7,7 +7,7 @@ from pymt.portprinter.port_printer import PortPrinter
 from pymt.testing.assertions import assert_isfile_and_remove
 
 
-def test_one_printer(setup):
+def test_one_printer(with_two_components):
     queue = PortPrinter.from_string(
         """
 [print.air__density]
@@ -23,7 +23,7 @@ port=air_port
     assert_isfile_and_remove("air__density_0000.vtu")
 
 
-def test_multiple_printers(setup):
+def test_multiple_printers(with_two_components):
     queue = PortPrinter.from_string(
         """
 [print.air__density]

--- a/pymt/portprinter/tests/test_vtk_port_printer.py
+++ b/pymt/portprinter/tests/test_vtk_port_printer.py
@@ -45,7 +45,7 @@ def test_multiple_files():
     assert_isfile_and_remove("sea_surface__temperature_0000.vtu")
 
 
-def test_port_as_string(setup):
+def test_port_as_string(with_two_components):
     printer = VtkPortPrinter("air_port", "air__density")
     printer.open()
     printer.write()


### PR DESCRIPTION
This pull request fixes errors related to some pytest fixtures. The problem was that I had two `conftest.py` files, each of which defined a fixture called `setup`. One `setup` was being overridden by the other, which caused the wrong fixture to be run for some tests. I've renamed the fixtures to have more descriptive (and different!) names.