### PR TITLE
Import find_model_data_files from model_metadata.find.

### DIFF
--- a/pymt/cmd/cmt_config.py
+++ b/pymt/cmd/cmt_config.py
@@ -8,7 +8,7 @@ import sys
 import six
 import yaml
 
-from model_metadata.metadata import find_model_data_files
+from model_metadata.find import find_model_data_files
 
 
 class redirect(object):


### PR DESCRIPTION
This pull request fixes an import from `model_metadata`, which slightly changed its API. There is no longer a `metadata` subpackage and `find_model_data_files` is now in `model_metadata.find`.