### PR TITLE
Import plugins into components module

### DIFF
--- a/pymt/component/component.py
+++ b/pymt/component/component.py
@@ -137,7 +137,7 @@ class Component(GridMixIn):
         provides=None,
         events=(),
         argv=(),
-        time_step=1.,
+        time_step=1.0,
         run_dir=".",
         name=None,
     ):
@@ -390,7 +390,7 @@ class Component(GridMixIn):
             argv = d["initialize_args"]
         except KeyError:
             argv = d.get("argv", [])
-        time_step = float(d.get("time_step", 1.))
+        time_step = float(d.get("time_step", 1.0))
         run_dir = d.get("run_dir", ".")
 
         events = []

--- a/pymt/component/model.py
+++ b/pymt/component/model.py
@@ -44,7 +44,7 @@ def get_exchange_item_mapping(items):
 
 
 class Model(object):
-    def __init__(self, components, driver=None, duration=0.):
+    def __init__(self, components, driver=None, duration=0.0):
         self._components = dict(components)
         self._driver = driver
         self._duration = duration

--- a/pymt/component/tests/test_grid_mixin.py
+++ b/pymt/component/tests/test_grid_mixin.py
@@ -1,8 +1,7 @@
 import numpy as np
 import pytest
-from pytest import approx
-
 from pymt.component.grid import GridMixIn
+from pytest import approx
 
 
 class Port(object):
@@ -55,10 +54,10 @@ def test_raster_1d():
             return (3,)
 
         def get_grid_spacing(self, grid_id):
-            return (2.,)
+            return (2.0,)
 
         def get_grid_origin(self, grid_id):
-            return (3.,)
+            return (3.0,)
 
     class Component(GridMixIn):
         def __init__(self):
@@ -66,7 +65,7 @@ def test_raster_1d():
             super(Component, self).__init__()
 
     c = Component()
-    assert c.get_x("invar") == approx(np.array([3., 5., 7.]))
+    assert c.get_x("invar") == approx(np.array([3.0, 5.0, 7.0]))
 
 
 def test_raster_2d():
@@ -75,10 +74,10 @@ def test_raster_2d():
             return (2, 3)
 
         def get_grid_spacing(self, grid_id):
-            return (2., 1.)
+            return (2.0, 1.0)
 
         def get_grid_origin(self, grid_id):
-            return (0., 0.)
+            return (0.0, 0.0)
 
     class Component(GridMixIn):
         def __init__(self):
@@ -88,8 +87,8 @@ def test_raster_2d():
     c = Component()
     assert c.name == "test-2d"
     assert c.get_grid_type(0) == "RASTER"
-    assert c.get_x(0) == approx(np.array([[0., 1., 2.], [0., 1., 2.]]))
-    assert c.get_y(0) == approx(np.array([[0., 0., 0.], [2., 2., 2.]]))
+    assert c.get_x(0) == approx(np.array([[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]]))
+    assert c.get_y(0) == approx(np.array([[0.0, 0.0, 0.0], [2.0, 2.0, 2.0]]))
     assert np.all(c.get_connectivity(0) == np.array([0, 1, 4, 3, 1, 2, 5, 4]))
     assert np.all(c.get_offset(0) == np.array([4, 8]))
 
@@ -100,10 +99,10 @@ def test_raster_3d():
             return (2, 2, 3)
 
         def get_grid_spacing(self, grid_id):
-            return (1., 2., 1.)
+            return (1.0, 2.0, 1.0)
 
         def get_grid_origin(self, grid_id):
-            return (0., 0., 0.)
+            return (0.0, 0.0, 0.0)
 
     class Component(GridMixIn):
         def __init__(self):
@@ -112,13 +111,19 @@ def test_raster_3d():
 
     c = Component()
     assert c.get_x(0) == approx(
-        np.array([[[0., 1., 2.], [0., 1., 2.]], [[0., 1., 2.], [0., 1., 2.]]])
+        np.array(
+            [[[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]], [[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]]]
+        )
     )
     assert c.get_y(0) == approx(
-        np.array([[[0., 0., 0.], [2., 2., 2.]], [[0., 0., 0.], [2., 2., 2.]]])
+        np.array(
+            [[[0.0, 0.0, 0.0], [2.0, 2.0, 2.0]], [[0.0, 0.0, 0.0], [2.0, 2.0, 2.0]]]
+        )
     )
     assert c.get_z(0) == approx(
-        np.array([[[0., 0., 0.], [0., 0., 0.]], [[1., 1., 1.], [1., 1., 1.]]])
+        np.array(
+            [[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]]
+        )
     )
 
 
@@ -128,10 +133,10 @@ def test_rectilinear():
             return (2, 3)
 
         def get_grid_x(self, grid_id):
-            return (0., 3., 4)
+            return (0.0, 3.0, 4)
 
         def get_grid_y(self, grid_id):
-            return (2., 7.)
+            return (2.0, 7.0)
 
     class Component(GridMixIn):
         def __init__(self):
@@ -140,8 +145,8 @@ def test_rectilinear():
 
     c = Component()
     assert c.get_grid_type(0) == "RECTILINEAR"
-    assert c.get_x(0) == approx(np.array([[0., 3., 4.], [0., 3., 4.]]))
-    assert c.get_y(0) == approx(np.array([[2., 2., 2.], [7., 7., 7.]]))
+    assert c.get_x(0) == approx(np.array([[0.0, 3.0, 4.0], [0.0, 3.0, 4.0]]))
+    assert c.get_y(0) == approx(np.array([[2.0, 2.0, 2.0], [7.0, 7.0, 7.0]]))
 
 
 def test_structured():
@@ -150,10 +155,10 @@ def test_structured():
             return (2, 3)
 
         def get_grid_x(self, grid_id):
-            return np.array([0., 1., 2., 0., 1., 2.])
+            return np.array([0.0, 1.0, 2.0, 0.0, 1.0, 2.0])
 
         def get_grid_y(self, grid_id):
-            return np.array([0., 1., 2., 1., 2., 3.])
+            return np.array([0.0, 1.0, 2.0, 1.0, 2.0, 3.0])
 
     class Component(GridMixIn):
         def __init__(self):
@@ -162,17 +167,17 @@ def test_structured():
 
     c = Component()
     assert c.get_grid_type(0) == "STRUCTURED"
-    assert c.get_x(0) == approx(np.array([0., 1., 2., 0., 1., 2.]))
-    assert c.get_y(0) == approx(np.array([0., 1., 2., 1., 2., 3.]))
+    assert c.get_x(0) == approx(np.array([0.0, 1.0, 2.0, 0.0, 1.0, 2.0]))
+    assert c.get_y(0) == approx(np.array([0.0, 1.0, 2.0, 1.0, 2.0, 3.0]))
 
 
 def test_unstructured():
     class UnstructuredPort(Port):
         def get_grid_x(self, grid_id):
-            return np.array([0., 1., 0., 1., 2.])
+            return np.array([0.0, 1.0, 0.0, 1.0, 2.0])
 
         def get_grid_y(self, grid_id):
-            return np.array([0., 0., 1., 1., 0.])
+            return np.array([0.0, 0.0, 1.0, 1.0, 0.0])
 
         def get_grid_connectivity(self, grid_id):
             return np.array([0, 1, 3, 2, 4, 3, 1])
@@ -187,8 +192,8 @@ def test_unstructured():
 
     c = Component()
     assert c.get_grid_type(0) == "UNSTRUCTURED"
-    assert c.get_x(0) == approx(np.array([0., 1., 0., 1., 2.]))
-    assert c.get_y(0) == approx(np.array([0., 0., 1., 1., 0.]))
+    assert c.get_x(0) == approx(np.array([0.0, 1.0, 0.0, 1.0, 2.0]))
+    assert c.get_y(0) == approx(np.array([0.0, 0.0, 1.0, 1.0, 0.0]))
 
 
 def test_get_grid_shape_is_none():
@@ -197,7 +202,7 @@ def test_get_grid_shape_is_none():
             return None
 
         def get_grid_x(self, grid_id):
-            return np.array([0., 1., 2.])
+            return np.array([0.0, 1.0, 2.0])
 
     class Component(GridMixIn):
         def __init__(self):
@@ -214,7 +219,7 @@ def test_get_grid_shape_raises():
             raise NotImplementedError("get_grid_shape")
 
         def get_grid_x(self, grid_id):
-            return np.array([0., 1., 2.])
+            return np.array([0.0, 1.0, 2.0])
 
     class Component(GridMixIn):
         def __init__(self):
@@ -231,7 +236,7 @@ def test_structured_1d():
             return (2, 3)
 
         def get_grid_x(self, grid_id):
-            return np.array([0., 1., 2.])
+            return np.array([0.0, 1.0, 2.0])
 
         def get_grid_y(self, grid_id):
             raise NotImplementedError("get_grid_y")

--- a/pymt/component/tests/test_map_component.py
+++ b/pymt/component/tests/test_map_component.py
@@ -1,8 +1,7 @@
 import os
 
-from six.moves import xrange
-
 from pymt.component.component import Component
+from six.moves import xrange
 
 
 def test_print_events(tmpdir, with_no_components):

--- a/pymt/component/tests/test_one_component.py
+++ b/pymt/component/tests/test_one_component.py
@@ -1,9 +1,8 @@
 import os
 
-from six.moves import xrange
-
 from pymt.component.component import Component
 from pymt.framework.services import del_component_instances
+from six.moves import xrange
 
 
 def test_no_events(with_no_components):
@@ -11,7 +10,7 @@ def test_no_events(with_no_components):
 
     comp = Component("AirPort", uses=[], provides=[], events=[])
     comp.go()
-    assert comp._port.current_time == 100.
+    assert comp._port.current_time == 100.0
 
 
 def test_from_string(with_no_components):
@@ -23,7 +22,7 @@ class: AirPort
     """
     comp = Component.from_string(contents)
     comp.go()
-    assert comp._port.current_time == 100.
+    assert comp._port.current_time == 100.0
 
 
 def test_print_events(tmpdir, with_no_components):
@@ -47,7 +46,7 @@ print:
         comp = Component.from_string(contents)
         comp.go()
 
-        assert comp._port.current_time == 100.
+        assert comp._port.current_time == 100.0
         assert os.path.isfile("earth_surface__temperature.nc")
         assert os.path.isfile("glacier_top_surface__slope.nc")
         for i in xrange(5):
@@ -59,10 +58,10 @@ def test_rerun(with_no_components):
 
     comp = Component("AirPort", uses=[], provides=[], events=[])
     comp.go()
-    assert comp._port.current_time == 100.
+    assert comp._port.current_time == 100.0
 
     comp.go()
-    assert comp._port.current_time == 100.
+    assert comp._port.current_time == 100.0
 
 
 def test_rerun_with_print(tmpdir, with_no_components):
@@ -81,7 +80,7 @@ print:
         comp = Component.from_string(contents)
         comp.go()
 
-        assert comp._port.current_time == 100.
+        assert comp._port.current_time == 100.0
         for i in xrange(5):
             assert os.path.isfile("earth_surface__temperature_%04d.vtu" % i)
             os.remove("earth_surface__temperature_%04d.vtu" % i)
@@ -91,6 +90,6 @@ print:
         comp = Component.from_string(contents)
         comp.go()
 
-        assert comp._port.current_time == 100.
+        assert comp._port.current_time == 100.0
         for i in xrange(5):
             assert os.path.isfile("earth_surface__temperature_%04d.vtu" % i)

--- a/pymt/component/tests/test_recursive.py
+++ b/pymt/component/tests/test_recursive.py
@@ -1,9 +1,8 @@
 import os
 
-from six.moves import xrange
-
 from pymt.component.component import Component
 from pymt.framework.services import del_component_instances
+from six.moves import xrange
 
 
 def test_no_events(with_no_components):
@@ -17,8 +16,8 @@ def test_no_events(with_no_components):
     air.connect("earth_port", earth)
     earth.go()
 
-    assert air._port.current_time == 100.
-    assert earth._port.current_time == 100.
+    assert air._port.current_time == 100.0
+    assert earth._port.current_time == 100.0
 
 
 def test_print_events(tmpdir, with_no_components):

--- a/pymt/component/tests/test_two_components.py
+++ b/pymt/component/tests/test_two_components.py
@@ -1,9 +1,8 @@
 import os
 
-from six.moves import xrange
-
 from pymt.component.component import Component
 from pymt.framework.services import del_component_instances
+from six.moves import xrange
 
 
 def test_no_events(with_no_components):
@@ -16,8 +15,8 @@ def test_no_events(with_no_components):
     earth.connect("air_port", air)
     earth.go()
 
-    assert earth._port.current_time == 100.
-    assert air._port.current_time == 100.
+    assert earth._port.current_time == 100.0
+    assert air._port.current_time == 100.0
 
 
 def test_print_events(tmpdir, with_no_components):

--- a/pymt/components.py
+++ b/pymt/components.py
@@ -8,4 +8,8 @@ for plugin in load_pymt_plugins():
     __all__.append(plugin.__name__)
     setattr(sys.modules[__name__], plugin.__name__, plugin)
 
-del sys, load_pymt_plugins, plugin
+try:
+    del plugin
+except NameError:
+    pass
+del sys, load_pymt_plugins

--- a/pymt/components.py
+++ b/pymt/components.py
@@ -1,9 +1,11 @@
 __all__ = []
 
 import sys
-from .plugin import load_csdms_plugins
 
+from .plugin import load_pymt_plugins
 
-for plugin in load_csdms_plugins():
+for plugin in load_pymt_plugins():
     __all__.append(plugin.__name__)
     setattr(sys.modules[__name__], plugin.__name__, plugin)
+
+del sys, load_pymt_plugins, plugin


### PR DESCRIPTION
This pull request changes which components are put into the `pymt.components` module. Previously "old-style" components were placed in the `pymt.components` module and "new-style" components were placed in the `pymt.plugins` object. Now all components are loaded into both places. So,
```python
import pymt.components
hydrotrend = pymt.components.Hydrotrend()
```
and
```python
from pymt import plugins
hydrotrend = plugins.Hydrotrend()
```
now do the same thing.