### PR TITLE
Make ESMF optional

### DIFF
--- a/pymt/grids/connectivity.py
+++ b/pymt/grids/connectivity.py
@@ -63,7 +63,7 @@ def _get_interior_ids(shape, dtype="int64"):
     obj = []
     for d in shape:
         obj.append(slice(0, d - 1))
-    return i[obj].flatten()
+    return i[tuple(obj)].flatten()
 
 
 def _get_offsets(shape, ordering="cw", dtype="int64"):

--- a/pymt/grids/esmp.py
+++ b/pymt/grids/esmp.py
@@ -241,8 +241,8 @@ else:
     _WITH_ESMF = True
 
 
-# if not _WITH_ESMF:
-#     __doc__ = "This module is not available (no ESMF installation was found)"
+if not _WITH_ESMF:
+    __doc__ = "This module is not available (no ESMF installation was found)"
 
 
 class EsmpGrid(IGrid):

--- a/pymt/mappers/esmp.py
+++ b/pymt/mappers/esmp.py
@@ -4,113 +4,120 @@ import numpy as np
 from .imapper import IGridMapper
 from .mapper import IncompatibleGridError
 from ..grids.esmp import EsmpUnstructuredField
-import ESMF
+
+try:
+    import ESMF
+except ImportError:
+    WITH_ESMF = False
+else:
+    WITH_ESMF = True
 
 
-class EsmpMapper(IGridMapper):
-    def test(self, dest_grid, src_grid):
-        raise NotImplementedError("test")
+if WITH_ESMF:
+    class EsmpMapper(IGridMapper):
+        def test(self, dest_grid, src_grid):
+            raise NotImplementedError("test")
 
-    def init_fields(self):
-        raise NotImplementedError("init_fields")
+        def init_fields(self):
+            raise NotImplementedError("init_fields")
 
-    def initialize(
-        self,
-        dest_grid,
-        src_grid,
-        method=ESMF.RegridMethod.CONSERVE,
-        unmapped=ESMF.UnmappedAction.ERROR,
-    ):
-        if not self.test(dest_grid, src_grid):
-            raise IncompatibleGridError(dest_grid.name, src_grid.name)
+        def initialize(
+            self,
+            dest_grid,
+            src_grid,
+            method=ESMF.RegridMethod.CONSERVE,
+            unmapped=ESMF.UnmappedAction.ERROR,
+        ):
+            if not self.test(dest_grid, src_grid):
+                raise IncompatibleGridError(dest_grid.name, src_grid.name)
 
-        self._src = EsmpUnstructuredField(
-            src_grid.get_x(),
-            src_grid.get_y(),
-            src_grid.get_connectivity(),
-            src_grid.get_offset(),
-        )
-        self._dst = EsmpUnstructuredField(
-            dest_grid.get_x(),
-            dest_grid.get_y(),
-            dest_grid.get_connectivity(),
-            dest_grid.get_offset(),
-        )
+            self._src = EsmpUnstructuredField(
+                src_grid.get_x(),
+                src_grid.get_y(),
+                src_grid.get_connectivity(),
+                src_grid.get_offset(),
+            )
+            self._dst = EsmpUnstructuredField(
+                dest_grid.get_x(),
+                dest_grid.get_y(),
+                dest_grid.get_connectivity(),
+                dest_grid.get_offset(),
+            )
 
-        self.init_fields()
-        self._regridder = ESMF.Regrid(
-            self.get_source_field(),
-            self.get_dest_field(),
-            regrid_method=method,
-            unmapped_action=unmapped,
-        )
+            self.init_fields()
+            self._regridder = ESMF.Regrid(
+                self.get_source_field(),
+                self.get_dest_field(),
+                regrid_method=method,
+                unmapped_action=unmapped,
+            )
 
-    def run(self, src_values, dest_values=None):
-        src_ptr = self.get_source_data()
-        src_ptr[:] = src_values
-        # src_ptr.data = src_values
+        def run(self, src_values, dest_values=None):
+            src_ptr = self.get_source_data()
+            src_ptr[:] = src_values
+            # src_ptr.data = src_values
 
-        # dst_ptr = ESMP.ESMP_FieldGetPtr(dst_field)
-        dst_ptr = self.get_dest_data()
+            # dst_ptr = ESMP.ESMP_FieldGetPtr(dst_field)
+            dst_ptr = self.get_dest_data()
 
-        if dest_values is not None:
-            dst_ptr[:] = dest_values
-            # dst_ptr.data = dest_values
-        else:
-            dst_ptr.fill(0.)
+            if dest_values is not None:
+                dst_ptr[:] = dest_values
+                # dst_ptr.data = dest_values
+            else:
+                dst_ptr.fill(0.)
 
-        # ESMP.ESMP_FieldRegrid(self.get_source_field(), self.get_dest_field(),
-        #                      self._routehandle)
-        self._regridder(self.get_source_field(), self.get_dest_field())
+            # ESMP.ESMP_FieldRegrid(self.get_source_field(), self.get_dest_field(),
+            #                      self._routehandle)
+            self._regridder(self.get_source_field(), self.get_dest_field())
 
-        return dest_values
+            return dest_values
 
-    def finalize(self):
-        pass
-        # ESMP.ESMP_FieldRegridRelease(self._routehandle)
+        def finalize(self):
+            pass
+            # ESMP.ESMP_FieldRegridRelease(self._routehandle)
 
-    def get_source_field(self):
-        return self._src.as_esmp("src")
+        def get_source_field(self):
+            return self._src.as_esmp("src")
 
-    def get_dest_field(self):
-        return self._dst.as_esmp("dst")
+        def get_dest_field(self):
+            return self._dst.as_esmp("dst")
 
-    def get_source_data(self):
-        return self._src.as_esmp("src").data
-        # return ESMP.ESMP_FieldGetPtr(self.get_source_field())
+        def get_source_data(self):
+            return self._src.as_esmp("src").data
+            # return ESMP.ESMP_FieldGetPtr(self.get_source_field())
 
-    def get_dest_data(self):
-        return self._dst.as_esmp("dst").data
-        # return ESMP.ESMP_FieldGetPtr(self.get_dest_field())
-
-
-class EsmpCellToCell(EsmpMapper):
-    def init_fields(self):
-        data = np.empty(self._src.get_cell_count(), dtype=np.float64)
-        self._src.add_field("src", data, centering="zonal")
-
-        data = np.empty(self._dst.get_cell_count(), dtype=np.float64)
-        self._dst.add_field("dst", data, centering="zonal")
-
-    def test(self, dst_grid, src_grid):
-        return all(np.diff(dst_grid.get_offset()) > 2) and all(
-            np.diff(src_grid.get_offset()) > 2
-        )
-
-    def name(self):
-        return "CellToCell"
+        def get_dest_data(self):
+            return self._dst.as_esmp("dst").data
+            # return ESMP.ESMP_FieldGetPtr(self.get_dest_field())
 
 
-class EsmpPointToPoint(EsmpMapper):
-    def init_fields(self):
-        data = np.empty(self._src.get_point_count(), dtype=np.float64)
-        self._src.add_field("src", data, centering="point")
+    class EsmpCellToCell(EsmpMapper):
+        def init_fields(self):
+            data = np.empty(self._src.get_cell_count(), dtype=np.float64)
+            self._src.add_field("src", data, centering="zonal")
 
-        data = np.empty(self._dst.get_point_count(), dtype=np.float64)
-        self._dst.add_field("dst", data, centering="point")
+            data = np.empty(self._dst.get_cell_count(), dtype=np.float64)
+            self._dst.add_field("dst", data, centering="zonal")
 
-    def test(self, dst_grid, src_grid):
-        return dst_grid is not None and src_grid is not None
+        def test(self, dst_grid, src_grid):
+            return all(np.diff(dst_grid.get_offset()) > 2) and all(
+                np.diff(src_grid.get_offset()) > 2
+            )
 
-    def name(self):
-        return "PointToPoint"
+        def name(self):
+            return "CellToCell"
+
+
+    class EsmpPointToPoint(EsmpMapper):
+        def init_fields(self):
+            data = np.empty(self._src.get_point_count(), dtype=np.float64)
+            self._src.add_field("src", data, centering="point")
+
+            data = np.empty(self._dst.get_point_count(), dtype=np.float64)
+            self._dst.add_field("dst", data, centering="point")
+
+        def test(self, dst_grid, src_grid):
+            return dst_grid is not None and src_grid is not None
+
+        def name(self):
+            return "PointToPoint"

--- a/tests/grids/test_esmp.py
+++ b/tests/grids/test_esmp.py
@@ -21,6 +21,9 @@ else:
     from pymt.grids.esmp import run_regridding
 
 
+esmf = pytest.importorskip("ESMF")
+
+
 def setup():
     ESMF.Manager()
 

--- a/tests/printers/nc/test_ugrid.py
+++ b/tests/printers/nc/test_ugrid.py
@@ -57,7 +57,7 @@ class FieldMixIn(object):
         from pymt.grids import RasterField
 
         ndims = kwds.pop("ndims", 1)
-        shape = np.random.random_integers(3, 101, ndims)
+        shape = np.random.randint(3, 101 + 1, ndims)
         spacing = (1. - np.random.random(ndims)) * 100.
         origin = (np.random.random(ndims) - .5) * 100.
 
@@ -67,7 +67,7 @@ class FieldMixIn(object):
         from pymt.grids import RectilinearField
 
         ndims = kwds.pop("ndims", 1)
-        shape = np.random.random_integers(2, 101, ndims)
+        shape = np.random.randint(2, 101 + 1, ndims)
         args = []
         for size in shape:
             args.append(np.cumsum((1. - np.random.random(size))))
@@ -78,7 +78,7 @@ class FieldMixIn(object):
         from pymt.grids import StructuredField
 
         ndims = kwds.pop("ndims", 1)
-        shape = np.random.random_integers(2, 101, ndims)
+        shape = np.random.randint(2, 101 + 1, ndims)
         np.prod(shape)
 
         coords = []


### PR DESCRIPTION
This pull request makes the *ESMF* (and *esmpy*) package optional. *pymt* only needs *ESMF* for the grid mappers so much of *pymt*'s capabilities are still usable without *ESMF*. This should also make it possible to install *pymt* on Windows (*ESMF* is not available for Windows).