### PR TITLE
Fix find_packages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,10 @@ import versioneer
 def read_requirements():
     import os
 
-
     path = os.path.dirname(os.path.abspath(__file__))
-    requirements_file = os.path.join(path, 'requirements.txt')
+    requirements_file = os.path.join(path, "requirements.txt")
     try:
-        with open(requirements_file, 'r') as req_fp:
+        with open(requirements_file, "r") as req_fp:
             requires = req_fp.read().split()
     except IOError:
         return []
@@ -18,18 +17,15 @@ def read_requirements():
         return [require.split() for require in requires]
 
 
-setup(name='PyMT',
-      version=versioneer.get_version(),
-      cmdclass=versioneer.get_cmdclass(),
-      description='The CSDMS Python Modeling Toolkit',
-      author='Eric Hutton',
-      author_email='huttone@colorado.edu',
-      url='http://csdms.colorado.edu',
-      setup_requires=['setuptools', ],
-      packages=find_packages(exclude=("tests*", "cmt")),
-      entry_points={
-          'console_scripts': [
-              'cmt-config=cmt.cmd.cmt_config:main',
-          ],
-      },
+setup(
+    name="pymt",
+    version=versioneer.get_version(),
+    cmdclass=versioneer.get_cmdclass(),
+    description="The CSDMS Python Modeling Toolkit",
+    author="Eric Hutton",
+    author_email="huttone@colorado.edu",
+    url="http://csdms.colorado.edu",
+    setup_requires=["setuptools"],
+    packages=find_packages(exclude=("tests*",)),
+    entry_points={"console_scripts": ["cmt-config=cmt.cmd.cmt_config:main"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(name='PyMT',
       author_email='huttone@colorado.edu',
       url='http://csdms.colorado.edu',
       setup_requires=['setuptools', ],
-      packages=find_packages(),
+      packages=find_packages(exclude=("tests*", "cmt")),
       entry_points={
           'console_scripts': [
               'cmt-config=cmt.cmd.cmt_config:main',


### PR DESCRIPTION
Change `setup.py` so that only `pymt` and `cmt` are installed as part of the package. Previously, the `tests` folder was also being installed.