### PR TITLE
hydrotrend.ipynb tweaks: add curl command and remove duplicate cells

### DIFF
--- a/docs/demos/hydrotrend.ipynb
+++ b/docs/demos/hydrotrend.ipynb
@@ -7,7 +7,10 @@
     "## HydroTrend\n",
     "\n",
     "* Link to this notebook: https://github.com/csdms/pymt/blob/master/docs/demos/hydrotrend.ipynb\n",
-    "* Install command: `$ conda install notebook pymt_hydrotrend`\n",
+    "* Package installation command: `$ conda install notebook pymt_hydrotrend`\n",
+    "* Command to download a local copy:\n",
+    "\n",
+    "  `$ curl -O https://raw.githubusercontent.com/csdms/pymt/master/docs/demos/hydrotrend.ipynb`\n",
     "\n",
     "HydroTrend is a 2D hydrological water balance and transport model that simulates water discharge and sediment load at a river outlet. You can read more about the model, find references or download the source code at: https://csdms.colorado.edu/wiki/Model:HydroTrend.\n",
     "\n",
@@ -21,7 +24,8 @@
     "loads are exceptionally high. It has been called the *\"dirtiest small river in the world\"*.\n",
     "\n",
     "To learn more about HydroTrend and its approach to sediment supply modeling, you can download\n",
-    "this [presentation][hydrotrend_presentation].\n\n",
+    "this [presentation][hydrotrend_presentation].\n",
+    "\n",
     "A more detailed description of applying HydroTrend to the Waipaoa basin, New Zealand has been published in WRR: [hydrotrend_waipaoa_paper]. \n",
     "\n",
     "A more detailed description of applying HydroTrend to the Waipaoa basin, New Zealand has been published in WRR: [hydrotrend_waipaoa_paper]. \n",
@@ -38,13 +42,6 @@
     "### Exercise\n",
     "To start, import numpy and matplotlib.\n"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-     "source": [ "### Exercise\n",
-     "To start, import numpy, matplotlib, and PyMT.\n"
-    ]
   },
   {
    "cell_type": "code",
@@ -64,12 +61,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [ "And load the HydroTrend plugin.\n"
-    ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
@@ -78,7 +69,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[33;01m➡ models: Hydrotrend\u001b[39;49;00m\n"
+      "\u001b[33;01m➡ models: FrostNumber, Ku, Hydrotrend\u001b[39;49;00m\n"
      ]
     }
    ],
@@ -200,7 +191,7 @@
     {
      "data": {
       "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x2ade35a6d208>]"
+       "[<matplotlib.lines.Line2D at 0x2adb97f5f5c0>]"
       ]
      },
      "execution_count": 8,
@@ -300,7 +291,7 @@
     {
      "data": {
       "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x2ade35ac9470>]"
+       "[<matplotlib.lines.Line2D at 0x2adb980dcda0>]"
       ]
      },
      "execution_count": 11,
@@ -363,7 +354,7 @@
     {
      "data": {
       "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x2ade35a59908>]"
+       "[<matplotlib.lines.Line2D at 0x2adb97f960b8>]"
       ]
      },
      "execution_count": 13,


### PR DESCRIPTION
Small changes to hydrotrend.ipynb to give users a command -- using curl -- to download a local copy of the Hydrotrend notebook.  

Also, clean up the notebook by removing a couple of duplicated informational cells.