### PR TITLE
Update ku.ipynb: add curl command and change imports to pymt.models

### DIFF
--- a/docs/demos/ku.ipynb
+++ b/docs/demos/ku.ipynb
@@ -8,6 +8,9 @@
     "\n",
     "* Link to this notebook: https://github.com/csdms/pymt/blob/master/docs/demos/ku.ipynb\n",
     "* Install command: `$ conda install notebook pymt_permamodel`\n",
+    "* Download local copy of notebook:\n",
+    "\n",
+    "  `$ curl -O https://raw.githubusercontent.com/csdms/pymt/master/docs/demos/ku.ipynb`\n",
     "\n",
     "### Introduction to Permafrost Processes - Lesson 2 Kudryavtsev Model\n",
     "\n",
@@ -71,38 +74,30 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load standard Python modules\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m✓ Avulsion\u001b[39;49;00m\n",
-      "\u001b[32m✓ Plume\u001b[39;49;00m\n",
-      "\u001b[32m✓ Sedflux3D\u001b[39;49;00m\n",
-      "\u001b[32m✓ Subside\u001b[39;49;00m\n",
-      "\u001b[32m✓ FrostNumber\u001b[39;49;00m\n",
-      "\u001b[32m✓ Ku\u001b[39;49;00m\n",
-      "\u001b[32m✓ Hydrotrend\u001b[39;49;00m\n",
-      "\u001b[32m✓ Child\u001b[39;49;00m\n",
-      "\u001b[32m✓ Cem\u001b[39;49;00m\n",
-      "\u001b[32m✓ Waves\u001b[39;49;00m\n"
+      "\u001b[33;01m➡ models: FrostNumber, Ku, Hydrotrend\u001b[39;49;00m\n"
      ]
     }
    ],
    "source": [
-    "import matplotlib.pyplot as plt\n",
-    "import numpy as np\n",
-    "\n",
-    "import pymt"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ku = pymt.plugins.Ku()"
+    "# Load PyMT model(s)\n",
+    "import pymt.models\n",
+    "ku = pymt.models.Ku()"
    ]
   },
   {
@@ -118,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -145,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -163,7 +158,7 @@
        "('soil__temperature', 'soil__active_layer_thickness')"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -174,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -183,7 +178,7 @@
        "array([ 0.25622575])"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -219,7 +214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,7 +223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -245,7 +240,7 @@
        "array([ 0.12506836])"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -258,7 +253,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -267,7 +262,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -284,7 +279,7 @@
        "array([ 0.29543607])"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -320,7 +315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -337,7 +332,7 @@
        "array([ 0.46966741])"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -351,7 +346,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -368,7 +363,7 @@
        "array([ 0.20328717])"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -409,7 +404,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -889,7 +884,7 @@
        "54                                        14.319  "
       ]
      },
-     "execution_count": 15,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -902,7 +897,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -913,7 +908,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -926,14 +921,14 @@
     }
    ],
    "source": [
-    "ku = pymt.plugins.Ku()\n",
+    "ku = pymt.models.Ku()\n",
     "args = ku.setup(end_year=2050)\n",
     "ku.initialize(*args)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -951,22 +946,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x1128eb198>]"
+       "[<matplotlib.lines.Line2D at 0x2b15ade5e400>]"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAD8CAYAAACMwORRAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvqOYd8AAAIABJREFUeJztvXl0XOd55vm8taM2AFXYSIAEwF2URG0UJUteJNuJZVuR7HTSbWcyJ0574unYOvEcZ5zI6W6n2z2ZmU5mkpwZa5K4e5x4OrYVx7FlWlYiO5a8yVpISRQlSlzADftWO2pfvvnj3q/qolDLvbdu4Raqvt85OiKKRfCyALz13ud73uclxhgEAoFA0F1YzL4AgUAgEBiPKO4CgUDQhYjiLhAIBF2IKO4CgUDQhYjiLhAIBF2IKO4CgUDQhYjiLhAIBF2IKO4CgUDQhYjiLhAIBF2Izay/eGhoiE1NTZn11wsEAsGO5OWXX15njA03e55pxX1qagqnT582668XCASCHQkRXVfzPCHLCAQCQRciirtAIBB0IaK4CwQCQRciirtAIBB0IaK4CwQCQRciirtAIBB0IaK4CwQCQRciirtAIOhJXr4ewRsLMbMvo22I4i4QCHqSf/fEG/jP/3Te7MtoG6qKOxE9QEQXiGiGiB6t85x/SURvEtE5IvqasZcpEAgExrISz2B9I2f2ZbSNpvEDRGQF8BiAXwAwD+AUEZ1kjL2peM5BAJ8DcC9jLEJEI+26YIFAIGiVXKGEcDIHh7V7xQs1/7ITAGYYY1cYYzkAjwN4uOo5vwXgMcZYBAAYY6vGXqZAIBAYx9pGFgAQTuXAGDP5atqDmuI+DmBO8fG8/JiSQwAOEdFzRPQCET1g1AUKBAKB0azGMwCkDj6VK5p8Ne1BTSok1Xis+q3OBuAggPsATAD4KRHdxBiLbvpERJ8A8AkA2Lt3r+aLFQgEAiNYTWTLvw4nc/A4TQvIbRtqOvd5AHsUH08AWKzxnO8wxvKMsasALkAq9ptgjH2JMXacMXZ8eLhpHLFAIBC0Bd65A0Ak1Z2HqmqK+ykAB4lomogcAD4C4GTVc54AcD8AENEQJJnmipEXKhAIBEZR3bl3I02LO2OsAOARAE8DeAvANxhj54joC0T0kPy0pwGEiOhNAM8C+CxjLNSuixYIBIJWWI1Xinu3du6qhCbG2FMAnqp67POKXzMAn5H/EwgEgo5mJZHBnkAf5sJphLrU6969Jk+BQCCow2o8i/3DXlgt1LWduyjuAoGg51hNZDHmd2HQ7UA4mTf7ctqCKO4CgaCnKBRLCCWzGPE5EfDYEenVA1WBQCDoJtY3cmAMGOadu5BlBALBTud6KInnZtbNvgxTWU1IHvdRnxMBj0N07gKBYOfzlz++gke+9orZl2Eq3AY54ndh0OMQB6oCgWDns5EtIJLKI5PvzjwVNfABphGfEwG3A5FUHqVS94WHieIuEPQQaTkkSznE02usyNEDQ14nBj0OFEsMiUzB5KsyHlHcBYIeIp2XithKItPkmd3LaiKLoMcBh82CgMcOAF15qCqKu0DQQ/DOfSXeu8V9LZHBsM8JABh0OwB0Z76MKO4CQQ/Bs8uXY71b3FcTWYz4XQCAgEcq7t3omBHFXSDoIfhBqjIVsddYiWcwWt25C1lGIBDsZNL53pZliiWG9Y0cRvxScRedu0Ag6ApSPa65h5M5FEsMIz5JlnE7rHDYLKJzFwgEO5uyLNOjVkj+pjYiyzJEhIDbgXAXxv6K4i4Q9Aj5Ygn5ojSs06ud+1qiMp3K6dYpVVHcBYIegevtIz4nkrkiNrLdN7jTDJ4rwzt3AAh6HMIKKRAIdi4ZWW+fCnoA9Gb3zuWoYUVxlzr37st0F8VdIOgR+GHqZNANAFjpQa/7SiKDAbcdLru1/FjAbRedu0Ag2LlwWWZqSO7cezCCYDWe3STJAFLnHkvnUSiWTLqq9iCKu0DQI6S2yDK955hZTWTLNkgO97pH090lzYjiLhD0CNwGOexzwuOw9qTmvpao0bm7u3OQSRR3gaBH4J17n92K0X5Xz3ndGWNYTWQ22SCBSufebbq7KO4CQY/ANfc+hwWjPlfPde6RVB75IqvfuXeZ110Ud4GgR+BWyD6HDaN+Z88dqJY97v7Nxb3SuQvNXSAQ7EBSOWloqc9uxajfhZV4Fox133q5enAZarRKlhlwSws7ROcuEAh2JOm8ZPVzO6wY8buQK5QQ7cLhnXpU58pwXHYrPA6r0NwFAsHOJC137k6bBaOyNNFL0kxlMbZry+8Nehy96ZYhogeI6AIRzRDRozV+/2NEtEZEZ+T//gfjL1UgELRCOl9En90KIipLE73kdV9LZOFz2tDnsG75vYDHgVCXFXdbsycQkRXAYwB+AcA8gFNEdJIx9mbVU/+OMfZIG65RIBAYQDpfhFsubKM+Xtx7qXPPbDlM5Qy6uy8ZUk3nfgLADGPsCmMsB+BxAA+397IEAm186muv4M9+cNHsy+hoUrliOVOFF7nVHiruK/Gt06mcQBcmQ6op7uMA5hQfz8uPVfMviOgsEX2TiPYYcnUCgUpevhbB2fmo2ZfR0WQUnbvLbsWA295TskzTzr0HizvVeKzaP/VdAFOMsWMA/hnAV2p+IqJPENFpIjq9tram7UoFggbE0nkks0WzL6OjSeWKm/TmXhpkYozVDA3jBDx2JHPFckRDN6CmuM8DUHbiEwAWlU9gjIUYY7wF+C8A7qj1iRhjX2KMHWeMHR8eHtZzvQLBFnKFEtL5IhI9uHxCC2mFLANI0kyvFPd4uoBsobTF484Z5OFhXWQNVVPcTwE4SETTROQA8BEAJ5VPIKJdig8fAvCWcZcoEDQmnpF+IJOiuDdEKcsAKA8y9QJ8OnW4Xufu7r58maZuGcZYgYgeAfA0ACuALzPGzhHRFwCcZoydBPA7RPQQgAKAMICPtfGaBYJNxOSo1l5cG6eFVK6I3QPK4u7E2kYWxRKD1VJLfe0eGnncgUoEQTc5ZpoWdwBgjD0F4Kmqxz6v+PXnAHzO2EvrDeKZPK6uJXHLngGzL2XHUi7uGVHcG5HOV2nufheKJYZQsr6LpFvgnftonQPVbkyGFBOqJvPfnr+OX/3L55Hvsi0w2wkv7rliCdlC9xyIGU06Jw0xcbj+3AvRv1x+qo775Qx2YecuirvJLMcyyBVLSIiuUzdxxQYd4ZipD59Q5VSmVLv/UHU1noXbYYXXWVusGOiTwsNE5y4wDN4pJDLdc0q/3cQ2FXfxJlkLxtimCVWgIlH0wqHqaiJT1wYJADarBf199q7yuovibjKV4i6Kkl5iCvuaeB1rky2UwBjgUhT3Ia8TRD3SuSeydSUZTsDjQLjHrJCCNhKRFwTEReeuG+VrJxwztUnLizrcClnGbrUg6OkNr/tqvHHnDgCDbtG5CwxEdO6tI2SZ5qTKK/Y2JyKO9sgg02qiuSOo2/JlRHE3GVHcWyeWzsNulXzaYkq1NmnFij0lvTDItJEtIJUr1rVBcgbdorgLDCKdKyIjb8cRB6r6iaXzGOuXujLRudeGZ6Yo3TKA1LmvdvnCDp58WS80jCNp7rmuWT0oiruJKD21onPXTyxdwPhAHwAxyFSPVK5ecXdhfSPX1XMWZY97E1lm0ONArlAqv1Y7HVHcTWRzcRedu17i6Tx29cvFXXTuNUnX1dylgreW6F5pht+ZNDtQ7bZ8GVHcTYQ7ZQDRubdCLJ3HgNsOj8Mqinsd+P7UWrIM0N12SP7G1cwK2W1TqqK4mwj/JrKQKO56KRRL2MgW0N9nh9dl6yhZ5qeX1vCDN1fMvgwAlc7dXdW5j/TAur2VeAZOmwV+V+MorYCnu6ZUVQWHCdpDVC7u44N9wueuE/6m2N9nh9dpw0auc4r7//3MDGKpPH7h6KjZl1LR3OvIMt3smJEGmJwgapx8OegWnbvAIMKyLLNn0I14B3WcOwnucfe75OLeQa9jOJnrGCcKt0K6qmSZoMcBq4Xa3rl/58wC3liItfXvqMdqPFteCN6ISjJkdzRaoribSCSVg89lw6DbIQ5UdcKLO5dlOskKGU7mEEnlkSuY70TJ1JFlLBbCiM/Z1s6dMYZH/+F1/NVPrrTt72hEo92pSvwuOyyErplSFcXdRCKpHAbdDvhcNqG566Rc3N12eBy2jjlQLZZY+fZ+bcN8ySOVK8JmIditW3/kR/yutt5hrG1kkc4XMRtKtu3vaIS0O7V5526xkDTIJGQZQatEUnkMenhxF527Hqo7904p7rF0HnwWphNshtWLOpSMtTmCYDaUAgBcD6fa9nfUI52TduvWW69XTcDjEJ27oHUiyRwG3Xb4XHZk8qWuHiRpF5uKu7Nzins4WSnoqx3gRKle1KGk3REEs3JRj6bym3KAtoPKBiZ1m6YGuyhfRhR3E4mkcgjIsgwg7JB62FLcM4WOGB8PbVQKxGqHd+6jfhdi6XxZlzea66FKxz4b2t7uvbI7VWXn7nYIt4ygdaKpPAbcDvhckr9WSDPaiWfycNgscNmt8LpsKJQYsh1wgKns/jqiuDfo3Hnha5c0MxdOgbsQr4e3V3dfUZkrw5E69+74ORTF3SRyBWn4RpJlROeul3g6D7/85shXqHWCNBOSi7vVQljrADtks84daJ/X/Xo4hZt290u/3u7OXWWuDCfgsSOSyqFUMv/ur1W6qrgXiiV8+vFXcfpa2OxLaQofYOIHqoBY2KGHWDqP/j7p9ePFvRPskLxznx7ydMQC6nSuuMUGyWn3LtXZcAo37PJhyOswRZaxWwmDbruq5w+6HSiWWFc0Wl1V3H82s47vnFnEP76xbPalNIXbrQbdjnLn2Q3fUNuNVNyl18/j7Jw7oHBSmmHYPdDXEbJMquGBavtkmVSugLVEFpNBD/YG3Nsuy0i7U11Np1M55UGmLtDdu6q4P/HqAgDg2ro5flot8NCwQY+QZVpBWdx9HSTLhJM5BDwOjPicHWGFzOSLW6ZTOf19djhtlra8Cc2F0wCAPQE3poKe7e/c41nVNkigEh7WDY6ZrinuyWwBT5+TQpqu7oTiXrNz721ZZmY1gTNzUU1/plbn3imyDC/u6xtZ0zXcdL6+LENEsh3S+M79ujy4NBlwY2/QjaV4pm2unFqsJjJNNzAp4bG/3eB175ri/oM3V5DOF3Hn1CBmwykUOtwzrizuXtG5AwD+t6fO47N//5qmPxNLVYo7fx07oXMPJXMIysW9UGKm3+Y3kmWA9u1S5R73vQE3JoNuMAbMR7ave1ezO1WJkGU6kCfOLGB8oA+/esceFEoM85G02ZfUkGhK6tIH3HbYrRb02a0937nPR9KaCkypxJCQ436BTpNlslLnLh9Wmn2oKrll6ofAjvhdbbnG2XAKPpcNA2479gY8ALbPMZMtFBFN5VV73AFFpnubOvd8sYT/64eXtiVErSuK+1oii59eWsfDt+7GvmHpG+iqSTkWagknc3A7rGUd1OeyIZ42vyiZyVIsjXimgGxB3W17IlsAY4C/SpYxOxmSMSbLMs5yYTEzHbJYYsgVSo07d58Ly/GM4QNgs+EU9gbcICJMBt0Atq+4l22QGmQZj8MKh9XSts59OZbBn/7goijuanny7CKKJYYP3zaO6SG5uK91dnHnoWEcn8uGRLZ3O/dktlCOPV7fUPeDFedxv3JxdzusIDJfc09kC8gXmSzLyJ27iYeqlRV79X/cR/1OpHJFw+96ZkOpclEPehzwOKxlqaadbGQL+F++9yYAYHrIq/rPEREGPfa2de5LMelNfre887edqCruRPQAEV0gohkierTB836FiBgRHTfuEpvzxJlFHN3lx8FRHwKyb/xah3fukWQOg56K99bnsve05s6/6QFgXWUhVEYPANIPptdhQ8Lk4h6W35wCHkfZqWGmYyZdXtRRX5ZpxyBTUZZH9wSk4k5E2Bv0lA9Z28W19SQ+/Nhz+Oe3VvHvHzyKO6cGNf35QXf7plSXYpJcvHtA/TmAXpoWdyKyAngMwPsBHAXwUSI6WuN5PgC/A+BFoy+yEVfXk3htLooP3zbOrwP7hjwd75iJpPJbOvdeXtixrCjuagthdXEH0BGr9vgtfcDjQJ/DCp/T1hnFvYEsw6ULI0POVuIZ5IolTMpaOyC5ZtqZDvnji2t46Is/w9pGFv/fvz6Bj799WrXHnRPwtC9fZjEqvb58oXs7UdO5nwAwwxi7whjLAXgcwMM1nvefAPwxgG0VF594dQFEwEO37i4/NrUDinu0Spbxu+w9faC6GKscgK+rzD+vWdydNiRNXrWn7NwBYNjvNFVzr7c/VckY79wNvE6ure+VO3cAmAy6MR9Oo2iwNZQxhr/88WX85l+/hN0DffjuI2/HvQeGdH2uwTbG/i5G0/C7bOXzoXaipriPA5hTfDwvP1aGiG4DsIcx9mSjT0REnyCi00R0em1tTfPFVsMYwxNnFnDP/uCmSM+poAcL0fS2+mm1Epbjfjm9vrBD2bm3Utw9TvNfRz4Aw4v7iM9pqlsmJb/ZNe7cjZdl5uQOnWvuALA36EauWMKygXcI6VwRv/P4Gfzv/3ge7795F771yXvKUpAeAm1c2LEUS2+L3g6oK+617mnKb7tEZAHwZwB+t9knYox9iTF2nDF2fHh4WP1V1uHMXBTXQyl86NZN7zXYN+wBY5Vvrk6jUCwhnimUbVcAen5hx1IsjSGvdF7Siizj64BVezw0LOjlxd3VEQeq9SZUAemOx+u0Gep1vx5OwmYh7Orf3HgBMEx3X4im8S/+4ud48uwifv+BI/jiR2+Du8HZghoGPQ7E0vm2zMosRjObXo92oqa4zwPYo/h4AsCi4mMfgJsA/IiIrgG4G8DJ7ThUfeLVBThtFjxw09imx/k30JUOlWaiclHarLn39sKOpVgGu/r7MOxzanLL2Cy0SW7ohFV74WQWLrulXGRGfJIsY1bOfL39qdWM+I29w5gNpzE+2AebYrUfl2iMiiH4zN+dwVw4hS9/7E789n37NevrtQh6HGAMbVksshRLY1cHde6nABwkomkicgD4CICT/DcZYzHG2BBjbIoxNgXgBQAPMcZOt+WKZfLFEr57dgnvPTpazkPnTMl2yE7NmFEmQnJ6PV9mKZrBWL8LQ171WSyxdB7+PvumH+hOOFCVplMr3uoRvxOZfMk0F0+q7JZpXNy5190oZkPJTXo7IFkA7VbCNQOK+0tXw3jxahif+cVDuP/wSMufj9OufJl0rohIKo/dndK5M8YKAB4B8DSAtwB8gzF2joi+QEQPtfsC6/GzS+sIJ3P4cJUkA0i36UGPo2MPVbnNarPm3tv5MkuxNHb3u+TOXX1xV0oyADpi1V5EzpXhmG2HVOOWAYyPIJgNp7Zo31YLYWLQjVkD0iG/+OwMgh4HPnLn3pY/lxKeL2N0cec2yO1wygCAKnGKMfYUgKeqHvt8nefe1/plNefbry5gwG3HOw/V1u6nO9gxo8yV4fRy584HmMb6+0BE+InGzl0JL+6MMUNu0fUQTuY23ZWVB5niWewfVj9QYxSVIaZmxV2KIDDitYtn8oik8piscbC5N+BueUr17HwUP7m4ht974HDTf5dW+PyJ0XZIPsuxaxs87sAOnVDdyBbw/TeX8eCxXXDYav8TOtkOWUuW4cmQvbiwo/xN3+/CkNeBRLagyukUr9W5u2woMSCTN+/sgoeGccyOIFDbuY/4XcgVS+Xco1aYrWGD5EwG3ZgNpVo6g/jiMzPwu2z47++e1P056lEODzN4kGkxKg8wbVPnviOL+/fPLSOTL21xySiZHvJgNZE13TlRi9qyTO927suK4s4lDDXSTC1Zpryww8Qoh3CVLMM7d7NkmZTK4m6k172cBhms3bknsgVEdL6JXFhO4PtvruBj905vOW8zAn5H3a7OfaxTNPdO5NuvLmBisA93TNYfKy5nzBjUvf/Bt1/Hv3/iDUM+VzSVg9Nm2fTDVu7c23BC3+ksKrTIIa96fVq5Yo/jK2e6mzPjkMkXkcoVNxV3f58NjjYtw1B7TU6bBRZLY6mF554rZw70ooz6rWayRTvkY8/OwOOw4jfvmdJ9fY1w2a1wO6xt0dyDHkdDS6qR7LjivprI4LmZdXz4tvGGuiAv7kZlzPzk4hqeeHXBEO+rNMDk2HT9ndS5X1nbwF8/d3XbFkzwYjLa71R07o1/sBhjiGcKdTt3sxwzZY+7orgTkTzIZJIs02BRhxLeUS4ZUNyvh1JyztPWzpoPNekJELu6nsSTZxfx63dPbpI1jWbQbfyU6mI0s216O6DyQLWT+O5rSygx4OEGkgxQ8bobkQ5ZKJawFMugWGI4txjHLXsGWvp8kVR+yzdmpyzseOb8Cj799TNIZAs4NtGPOyYDbf87+QCT02ZV3bknc0UUS6ymWwYwT5apjh7gjPicWFPpAjKaZos6OGN+F6wWwoIBuxDmajhlOLyb13Oo+hc/moHdasHH3zHd0vU1I+Axfkp1KZYu37VsBzuuc3/7gSE8+v4jODDS2HXQ57BiV7/LkFx3XtgB4OeXQy1/Pinud3NRMnthB2MMX3zmEj7+ldMYH5QOfF68Gt6Wv3splil3jXyqs5nmzgdM/K7axd0sWYYXBP7v4AybGEGQzhfhUtG526wWjPldWIi2Xtyvh5M1nTKAJHuM+V2ai/tCNI1vvbKAj9y5R9N2JT20I19mKZrZNo87sAOL++ExH/7Nu/areu5U0BjHzJy8FsxCwPNXjCruW28pzcqXSWYL+ORXX8H/8f2LeOiW3fj2J+/FwREvXtqm4r4sT6cCgNNmRX+fvWnnHkttjR4AlKv2TOrck9J1V399zYwgSOfUyTIAMD7Q13Lnni+WsBjN1NTbOXuD2r3uf/XjyyACPqHy578VAm67oZ17IpNHIlvYtlwZYAcWdy1MD3sMmVKdlze4v+vQME5dDSNXaE13j6bym7LcOWYs7LgeSuKX/5+f4+lzy/i3H7gBf/6vbkWfw4oT0wGcvhbZll20i9H0prwNNYNMtXJlgErnvmFS5x7a4Jr75u0/Iz4nYum8KWF2aZWyDACMD/a13LkvRaU73VpOGc6kRq/7aiKDx0/N4Zdvm8D4NhRIqXM37mex4nEXxd0QpoMeRFL5sq9cL3ORFCwE/PLtE0jnizg7H9X9uUoltiXul7PdCzt+emkND33xOSzHM/jKvz6B33rnvvIh74npADayBby1lGjrNfABJuXU3pDXoV6WqVfcTTq7CCdzsFkI/ioXD89LV2uH/NJPLuMHb64Yck3N9qcqGR/ow3I809Kb+nW5I2/UuU8G3VhNZMuJlc34rz+9ikKxhN++r/1dOyBNqW5k1a98bEbF4y5kGUMwyg45F05hV38f3n5gCESt6e7xTB4ltvW2HdjehR3/7flr+I0vv4QxvwsnH7kX7zi4edL3rukgAODFq63LUI1QDjBx1OTLxOt07i67BVYLmTbfwKdTq51cWtbtFUsM/+f3L+IvfjRjyDVJnbu6H/XxwT4US6yljJnZGlG/1eyVDxbVOGYiyRz+9oXr+KVbdpdzo9pNZVG2Md276NwNZsqo4h5JY0+gD4MeB24Y8+P5Foo7987WkmW2a2HH6/Mx/Ifvvol3HRrGtz55T80T/LF+FyaD7rbr7ss1BjvUJEOWZZmqg2kigsdhNS1fpno6lVPJl2leNK+HksgWSjg7HzPkTSqd1yDLyMWnFd19NpSCw2bBaINDz0kNjpm/fu4qUrkiPnX/Ad3XpJUJ2VRglJV6MZqGhYBRn/pl3a3S1cV9b8ANC7WeDjkXTmHPoPTN+Lb9Qbw8G9GtnfKpvAGTDlRzhRI++83XEPQ48Of/6raGG2FOTAVw6lq4rX738k7JTbKMExvZQnlsvhbxTB4WArw15AYz99FWT6dytMgy55clKaxQYnj5eqTla0rlNMgyclFrRXefDaewZ7Cv4dBU2evepLgnswX8zc+v4X03juLQqE/3NWnlyJgfgDQNawSL0QxGfK5N8cftpquLu8NmwcSgu6Vc90y+iNVEtuzZvWd/ELlCCa/M6vuh4/p/oG5xb2/n/hc/uozzywn80Ydv3tL1VnNiOoBIKo9Lqxttu54lxQATR00EQSydh89lr1lAPE6rabJMdSIkJ+hxwkLqZJnzS3FYCLBZCC8Y4M7KbHPnfj2Uaqi3A1Jz43fZyvp8PU6+toh4poDfesc+3dejh1G/E/199vIbbatIOe7bp7cDXV7cAUl3b+XWal7+Jt8TkL7p75wOwELACzqlmbIsU6O4+9u8sOP8chxffPYSHrplN37h6GjT53Pd/aU26u5LsUx5gIkz7OVBW42Le7XezjEz9jdUp7hbLYSgV53X/fxyAtNDHhyb6G+5uDPGVE+oApIHfcjr0N25M8YwF25e3AEphqCZLPP1l2ZxaNTbMGqkHRARDo/5cGE5bsjnW4plti0wjNMTxf3qWlJ3Ah33uHNZxu+y4+aJAd2Hqjxxr54VEmjPlGqhWMJn//4s/C47/sNDN6r6M3sCfRjzu9o6zLQUS28JUlLbudct7i67KcU9Xywhls7XLO5AZSNTM84vJ3BkzI+79wVb1t1zxRKKJaYpFnd8oK/c1GglkpL83HtVTGJOBt0ND1TfWIjh7HwMv3ZirynxzUfGfLi4stHyBi3G2Ba773bQE8U9mSvqHv2el7/5JgYrncjb9gVxZi6q2salJJySrHLeGlp3Oxd2/JefXsXrCzF84eGb6hafaogId+0L4KWr4batiFMOMHF4BIHu4u4050CVpwjWOlAFeHFv/H24kS1gNpzCkTEf3rY/iEKJ4XQLunsmJ90FagmrasXr3igwrJrJoBsLkXRd2+VXX5yFy27Bh2+f0HUtrXJ4zIeNbEH3Gx0nksojWyhtq1MG6IHiXnbM6MyYmYuk4bBZypncAMo/dKeuaf+hi6ZqW+WASuceTxtbmGZWN/Bn/3wRD9w4hg/cPNb8Dyg4MR3AaiJryFq0WtTqaPjofqPDx6ayjAkHqlxyC3hqOyLUTKnyA7wju/y4Y3KwZd09lZdeB7WyDCBPqUbTug7SedJjIxskZzLgQaHEsBjdejezkS3g5JkFPHhsd92vc7s5MiYd4LZ6qGqGxx0p3Co7AAAgAElEQVTogeK+r8V0yPlIChMDm0/+75ySfuj0WCKlRMja36zt6NyLJYbf++ZrcDus+MKHbtR8e3vXtBQc1g7dvbKBafM3vd1qwaDb3rBzj9fYwsTxOG2mHKjWCw3jjPidCG1kyzlFtSgX9zEf3A4bbtkz0FJxV7uoQ8nEoBu5QgnrSe13u3PhzTJmI/gEa61D1ZNnFpHMFfFrdxm7Qk8L3J1zYaW14m6Gxx3ogeK+e6APDqsFV9f1dZ5z4TQmqm4x3Q4bbt0zgOcvr2v+fJFUvqYNElB07gZ2nX/z82t4ZTaKP/ylo7rClvYPexHwONqiu/NBmVoHTY0GmRhjiKe3xv1yfE4bNnKFtklJ9SjH/XrryzIlBoQaFM3zy3F4nbayz/rufYGWdHe1K/aUtOKYuR5KYcTnVPX38e6+1l3h1166jiNjPtzWYgJrK/hcdowP9LXsmKnYfUXnbihWC2Fv0I2r6/rsfHMRybNbzT37g3h9IaZ5LV40latpgwQqCYdGde7XQ0n8ydPn8Z4jIw23VjWCiHBiKtCWYaalaP3NNI0GmTL5EnLF0pYRf47HaQNjlQ1E2wXX3Ot17sOKXar1OL+UwOExX/kO6+59QRRb0N31dO6teN1nVTplAGDU54LDZsFs1V312fko3liI49fuMucgVckRAxwzi9EM7FYqnyVtF11f3AEpHfKajs49kckjmsrXzKW+e38QJQac0lj0wsnaoWGAsW6ZUonh9//hLOwWC/7owze39ENy174A5iNpQ6JgldQaYOI06tzrhYZxKsmQ2yvN8NCwgTrXVZlSrX9Hcn45XtZ6AbSsu/POXZPmPqi/c58NpxoGhimxWKjmsuyvvTiLPrsVH7pNX0NiJIfHfLiylmwpLHAplsao39V0E5bR9ERxnx5y41ooqfmAaE5Og6ylH96+dxAOm0WTJZKx+qFhgLELO84uxPDClTB+74HDLe9sPNEm3Z1rkXx6U0mjZMimxd1pTnEPJ3MYcNvrTiE2W5S9FMsgnilsKu6t6u787kWLW8bvssPnsml+M8/ki1iON476rWYysNkOmcjkcfK1RfzSLbu2ZPWbweExHwolhstr+gf5lqKZbY365fRIcfciWyhhSWMYUtnjHtj6hXHZrbhj76CmQ9VEtoBCidUt7kYu7OCZLbftbX3448iYHz6XzXBpZimWqbtTcsjrRCpXrKk1qy7u2+yYqRc9wOGdez1Z5rx8+39kl3/T463o7hkdmjugL9d9PpIGY+qcMpy9stedn49858wiUrkifu2uSU1/d7swIoZgMZbedr0d6JHiPjUkfbNptUM2O/m/Z38Qby7FVW9siSZ5rkz9jsSofBluyzNC57NaCHdOBQw/VG00kj3UYCNTp3buoWS2rscdkBqC/j57XTskj1c+PLY5Q4Xr7qeuaX/9ueauRZYBpOAsrZ37nAaPO2cy4EZKnkNhjOFrL87ihl1+3DLRr+nvbhfTQx7YLKT7ULVUYliJZ7bdKQP0SHHfNySt5NO6cm8+kobXaatbjN+2X1ssbrjJgRtg3MKOkFwU6+n7WrlrOoAra0nVeeRqWI5lMOav/U3faEq1WXH3mCjLNBsQG/HVP0u4sJzA+EDfFjnijslB2K2EF65oL+4pHQeqgL7OvTLApD6Wd1K2Ks+GUnhtPoY3lzrjIJXjsFmwf9ir+1B1fSOLfJGJzr1djPqd6LNbdXXuE4N9db/Rjk0MwO2wqtbduZuinhUSMC7RMJTMwee0bcpsaYWK7m5c974Uy2B33c69/uFjs+LOD6bNkWUa3ymN+OtHEFQfpnLcDhtumdCnu+uxQgLSoWoiWyi/1mq4HkrB7bCW77rUoIz+/fqLs3A7rPjQrbs1XWu7kTJm9HXui+V9BaJzbwtEhCkdAWJzkdSm2IFqHDYLjk8FVOvuUZWduxE+93AyV9dvrYebxvvRZ7cadqiaykmFo95hLz98XKthh+SLOnx1Dtx4557UEQ+hl1KJIZLKN5RlgPpTqtlCEZfXkjiyq3as7d37JOut1ruRdK4ICwEOjVGz4wPS972W7p3bILV03RODUiz3ucU4Tr62iIdu2V3362oWh8d8WIxlNL3RcZZkaWu7EyGBHinugOSY0bK0Q0q3S9c8TFXytn1BXFrdUBUIFZY193oTqoC0Ns6IA9VQMqs6Q0YNdqsFd0wOGqa7c6dMvaS8gMcBovqdu89pg7WOtYxr7tuZ6R7P5FEssfIGn3oMy/ky1QNWM6sbKJZY+QCvmrLfXaPuzhd1aJU59HjdZ8PJmrbhRjhsFuzq78PXX5pFOm/uRGo9+N3URR2TqgvR+nbfdqOquBPRA0R0gYhmiOjRGr//b4jodSI6Q0Q/I6Kjxl9qa0wPeTAXTqmO0w0lc0jni03HqO+RdXc1emg0lYOF0NDi5TfoQDW00Vwi0MqJ6QAurCRa3kkLNB5gAgCb1YKAu/Yu1UbRAwDgtFlgt9K2au7l6VQVmnuuUNqSH8Rv+2+o07nfPjmgS3fXsj9VSWVKVd18CGMMs+FUWWbRwmTQjXS+iBt3+3HzeGccpCrhB9x6DlWXYhm47JaGJop20bS4E5EVwGMA3g/gKICP1ijeX2OM3cwYuxXAHwP4U8OvtEWmglJIkdqEt0qOe+Nv1ht3++Fz2lRJM5IP2tFwmMHnspdlh1YIJ3OatE813DUdAGPAaR2BadXwAaZGMahDXifW63TujcKkiGjb82UqoWHNO3dgq9f9/HICDpsFU3WicvXq7ulcEX0O7TfoUsa+RXXnvpbIIpMvqR5gUsKtk510kKpkfKAPPqdN16HqUiyN3f31z+3aiZqv+gkAM4yxK4yxHIDHATysfAJjTPmv9gDY3lAPFewblgPEVEozZRtkE1nGZrXgrn0BVTkz0VS+6Tu4z2lDtlBqaSKOMabKuaGVW/YMwGG1GLI0u7yByd+guPscNaOamxV3YPuTIUNNQsM49RZlv7UUx8ERb8M1bHp093SuCLdde+dORJpy3WfLPy/ai/sdkwGM+V14WGdERrshIhzSeai6GM2YorcD6or7OIA5xcfz8mObIKJPEdFlSJ377xhzecbBOyK1K/eql3Q04u59QVwLpcrRnvWINMiV4VQiCPR37/G0NCwVNDjLwmW34tY9A4Y4ZhoNMHGGvbWnVFUXdxM692aH2PV2qV6QF3Q0Qo/unsoX4dLolOFoyXW/uCJNcPIUVi38yh0TeP5z766546BTODzmw/nlhOYwuqVY2hSnDKCuuNe6n9jyL2SMPcYY2w/g9wH8u5qfiOgTRHSaiE6vra1pu9IWCXiknY3qO/c0Ah5HwwXSnHv2DwFAU0skl2UaUYn91V+YeOpgM/1XDyemA3hjMd5y4VxWsVOS58tU/0B1YnFvFhrGqRVBENrIYjWRrWmDVML97s9rkGYyuSL67Pp8ExOD6r3ur8xGEPQ4NA0wKelEOUbJkTEfEplC+Y5TDfliCauJrCked0BdcZ8HsEfx8QSAxQbPfxzAh2r9BmPsS4yx44yx48PDw+qv0gCISFq5p7K4z9dJg6zFkTEfAh4Hfj7TWJqJpvIINBkqMiI8LKRS/9XDiekAiiWGV1rYDgRInXu9ASbOsM+JTL6EZFW6YzyTb7rce7s199BGDl4VcwVepw19duumCILKgo7Gxb3PId05aTlUTeULcOs4UAUkrTmUzJWnXBvxyvUIbp8c7PgirZfDo9oXd6zEM2Bs+3PcOWqK+ykAB4lomogcAD4C4KTyCUR0UPHhBwFcMu4SjWN6yINLq+purebCqS057vWwWAhv2x/Ec5fX635uxhjCDULDOEYs7OD6r5E+d84dk4OwWkjXKLySpVim6U7JWoNM2UIRmXwJflfjguV12ZBQWdyfPrfcVFJrRjiZVTUNTERlOyTnrfKCjsayDCBJM28sxFR/f6RzRc3TqRy1dshwMocr60ncbkCOUafCvzZaHDPlJR2d2rkzxgoAHgHwNIC3AHyDMXaOiL5ARA/JT3uEiM4R0RkAnwHwG2274hY4MR3ESjyLmdXGCW/FEsNCNK1Kb+fcu38IK/FsXU0/nS8iVyipkGVaX9hRkWWMz4/2OG2YHvKUc1D0wAeYmskytSIImk2ncnwqD1Qz+SJ++29fxleev9b0uY0IqZhO5VQvyr6wHMeQ11H+9zZCa757Jl/SPJ3KKQ8yNSnu/C7ujsnuLe79bjvG/C5Njpnyej2TOndV92uMsacAPFX12OcVv/60wdfVFu47LElBz15YxcHR+rfAK/EM8kVW3oajBu53//nMOvYPe7f8fsUq17goGbGwg697MypXpppDo16cW9S/wEBtR1NelK3ocrlNtJHPHVAvyyxG0ygxYEWDllqLcDLX0PmjZMTv3NQBnl9ObAkLq8fte3nOTAj3Hx5p+vxUrtB6595Ed395NgKbhXCsQ8K+2sXhMR8urKiP/u34zr2b2D3Qh8OjPvzoQuPD3Dkdtq7JoBvjA314bqb2YVc0xRMh1bplWtPcfS7jcmWqOTjiw2w4VY6T1QofYGrmIhjyyYuydXTuXqcNyVyxaYY/t/o1W1zdDC3W0xGfqyw1FUtMlVOGo1V3l4aY9H0fjPqcsFoIC9HGg0yvXI/gxvF+TZnxO5EjYz5cXt1QPQi5FE3D57KZFqfQU8UdAO47MoxT18INnRRzfIBJQ+dORLhnfxDPXwnVXICs1k1hxMKOUDLXFqcM59CoD4yhqbxVDzUDTIAkK1loc+eupbgDzfNluOSwojHrXwljTNNrPuxzIpEpIJMv4looiWyh1NQpo+Su6SBen482PegslZgky+gsujarBWN+V8POPV8s4bX5KO7oYr2dc3jMh1yxpNpxtxjLmBI7wOm94n5oBPkiw3MNnC1z4RSIKrelarn3wBBi6TzeWtoqWXBZplGuDGDMwo6wwbky1RwclWSnS6v6dPdlFQNMgJQjH/A49HXuKlftzcvzDK107qmcdJ6ivnOvLO2oxA6o69wByRhQYs3fkDIFfYmQSpp53d9aiiOTL+H2SfMWWW8XWmMIGu0r2A56rrgfnxqE12nDjy6s1n3OfCSNUZ9Ls6zB891rvXFwWaaZWwYA/H2t5cuENnKGDzApmQpKCwwuadAflSyqGGDiSF73SpZNLKWxc29S3HlXmsgUVFn+aqE2eoAz4udTqhmcX4rDQsCBka3nNPX/vPS1bVbc9S7qUDLRJNf95R44TOUcGPHCaiHVdsilaMa0ASagB4u73WrB2w8M4UcX1uraFuciqaaxA7UY9btwYMSL52oMM/EC0KwoAXKmewsLO9otyzhsFkwPecpTiVpZjqVV73Wt3qXKXUTNDlTVJkMqu1I1yZ610DpXMOzlg0xZvLWcwPSQR5NePeqvHWFQjZ79qdWMD/ZhOZ6pqzO/fD2C3f0uU4vYduG0WTE95FHVuWfyRYSSOdMGmIAeLO4AcP+RYSzFMrhQJ8JzPpzSZINUcu/+IE5dDW/JhommcvC7bA2zQzitrNpjjCHShlyZag6N+nTLMpLHXV0xGPZu3lwUS+fhdlhhb/I6qpdl0oqpUX3STFi2nqrv3Lksk5EOUzVIMkBF1mkqy+T1bWFSMj7QhxKrSGnVvDobxe090LVzJMdMc6cYf73MGmACerS4v+uQZCGr5ZrJyYu01Q4wVXPPgSGk80WcmYtuejySyqv+4W8lGbJduTLVHBjxYjac0iVlqBlg4gzJnTu/y1ITPQAAHkdzWSZXKGElnikP3+g9VC0Pjan0uQfcDtgshKvrScyGUzjSwJZbi/4+Oxw2i+rOvRVZptEg01IsjYVouickGc6RUR/mwummTcNijOe4i859Wxnrd+GGXX48e36r7r4YlTa4a3HKKLl7XxAW2qq7R1LNc2U4rXTu623MlVHCHTOX17RJM2oHmDhDXgeyhVJ52lRtcVdjKV2OZVBiKB8GKiMBtFDW3FVOBFsshCGvEz+Tv0e0du5EhFG/E6vNNHeDOnegttf9letSA9PNk6nVHFa5uGMxKjp307jv8DBevh5BvMqVUk6D1Nm59/fZcdN4P35+eWtxV9u5+1tYtac2nbBVDul0zGgd7ChPqcpdaqzJog6OR8WB6rzs375xdz8cVgtWdGru4WQODpsFHg0d8ojficvyTl8tNsjyn/e5sNLkzUjv/lQlfLqyVvTvy9cjcNktOLpb25vTTobPIzQ7VC2v1xOd+/Zz/+ERFEoMz13aXITnwtIXRct0ajX37B/Cq7PRTYUlkmye5c6RlmTrk2VCG9r0X71MDUmOGa2HqlyLbBYaxqnOl4mrlWWcUkFrdPtcXsgy6Mawz4m1Fjr3oMehKTSL6+Zep03X99pog0XbHC6ZtVLcXXYrhrzOmoNML89GcGxioOn5RzcxMdgHt8PatLgvxjIIqHSEtYve+apUcfveAfhcti26+1wkBZuFWjr9v/dAEIUS2xSuFVERGsZpZWFHZd1bezV3u1VyzFzSuFeykrehsXOXdW21sozTZoXDZmkYHrYQSYNIkulG/M6WOnetb6bD8tKOw2M+XUmKIz5XUxmpXNxbLDATNbzumXwRby7GekpvByRJ7dCoD+ebZMxIOe7mde1ADxd3m9WCdx4cxo8urm6yRM6FU9g90Fd3+bIajk8G4LBayvnumXwRqVxRw4Gq/oUdYZUbgYxAcszo69zV5rCU82U2tHXugBxB0KRzH/W54LBZMKqiWNYjpKu4S/8uPZIMIMk6iWwBqQYTuCkDZBlAHmSqkmVeX4ghX2Q9MZlazRF5K1OjdFmzPe5ADxd3AHjX4WGsxLObEg7nImldHnclfQ4rbts7UD5UreTKqJdlAH0RBDxXxmFr/5f24Kh2x4yWASZAGvqyWghriSzyRSnbvdGCcSXNVu0tRFNlSWTE79TtltHTuXNZRuthauXPy173Bm9IGaM694E+LEYzm3J6+PDSbXu7fzK1msNjPkRS+S3btJQsxtKq707bRU8X9/sOVVIiOa143JXce2AIby7FEUnmKrkyGtwygP7i3m6nDEePY0bLABNQiSBY38iW7aH9feqWT3icNmxk67/xLETTZavfqN+FuJz3ohU9xZ1vLLp5XF+S4qiKKVUj3DKA1LnniqVNw2QvX49gesjTdsttJ9IshmAjW0AiUxCdu5mM+F24adyPH8u6eypXQCiZ0+2UUXLvgSAYA164EkJE1sHVWyH1x/6Gk9lt+4HjjplmtjAlWjzuHD7IVM6VUXsH5LRho86kb7HEsBTNlDt3LpM06sZqkS0UsZEtaH5DfcfBIXz7k/fg1j36Ol81U6qpXBEOq0XV4FwjuB1yXtbdGWN4dTbSUxZIJdwx8/S55S1uO6DilBGdu8ncd2gEL89GEEvny+6JVpwynGMTA/A4rHju8joisiyjVXPXY4cMbbR/OpUzGfTAbiVNuruW6VQOH2RSGxrG8TitSNbp3FfiGRRKrLyQghdLrdJMJVdG2xsqEeG2FoqjminVTL4Il879qUqqc91nwymsb+R67jCVE/A4cM/+IL764iyO/6d/xsf/5hS+9cp8udAvyudKZi3p4HTuuvFt4v4jw/jiszP42aX18g+CEZ273WrBiekAfj4TwmH5nb5ZIiSnlYUdoWROdzeoFa2OGT7ApEWWAaRBppmVhObi7nXZcS1UO4u8+o1cbwSB1tAwo+BTqo3uNFI5/ftTlZQHmeSOtJfCwurxtx+/C2fmo3jq7BKeen0JPzy/CofVgnccHCo3Z2a7ZXq+uN+6ZxD9fXY8e2EVN8nDGEZo7oCkuz974a1yBLBaWcbfp09zL5WkXJl2DzApOTjqw+vzMVXP5c+rtamqEVJ4WE57cXfWn/Tlvu3xquKuv3Pf3uJORBjxNT4ETrewYk+Jz2WH32Urd+4vX4/A57ThoIYky27DYiHcvncQt+8dxB984IZNhX4xloHdSqodYe2i54u71UJ456Fh/PjiGvwuO1x2C4YMKo737B8CAPzTG8vwOtU7WNQmGlYTz+RRKDHNEkErHBrx4anXl6RFzE0KyTPnV2G3Et5+cEjT3zHsdSJXLJW7bTUTqgDgdVrrWiHn5WE13pUOuh2wW2nHdO6AJCU1mlJtZTl2NeOD7k2d+617B2BpwS7cTdQq9LlCyfThrp7X3AHJNbOWyOIHby1jYtCta6ikFkfGfAh4HAgnc6ptkIDkwXc7rDUPaxpRGWDazs7dq9ox88Pzq7h7X7D85qUWfth5Wdb21Vsh7UjniyjUiKtdiKYx5HWWLZkWC2HYq90OWQkNM6O4N55STecLhnTugPQmuBBJI5HJ4+JKoqclmUbwQn/3vqDZlyKKOyD53QEpekBvYFgtLBbC2+QvstbOTgoP01jcN7YnV0aJWsfM9VASM6sbePeR5kudq+GDTJfXNuC0WVR75HkEQbKGD19pg+SM+F2a3TLhZA5WC6mWioyk2ZSqkZ07n1I9MxdFifW23r5TEMUdUvHgm9uNOExVcs8Bqbir1ds5Ur6MNllGa664EXDHTLOMmWfkBE49xb3cua8lNRVRX4NM9/lIeosrqpmGXYtQModBt90UiaLZlGpKhVSmlvGBPmxkC3j2/BqIsG2H9gL9iOIuc99hqegYdZjKuVfW3dU6ZTh6Yn+5LDO0jYMldqsF+4a8TR0zz5xfxf5hDyaDHs1/B//3bGQLmoo7T4asnlItlRgWomlMVFnVRv0uzZr7dixGqUezKdVM3kjNXXqtnjy7iMOjvvIshqBzEcVd5hePjgIADunM+qjHZNCNE9MB3Kax09GTDMllGbUBZUZxcNTb0Ou+kS3ghSshvOeGUV2ff6DPXs760VLcubZf3bmvb2SRK5Rqdu7RVF7TlKqe6VSj4FOq9d6QUrliS4s6lPCD59VEtqc2L+1kRHGXuWm8Hz/57P14p0YnRzOICN/4H9+Gj907renP6encw9uYK6Pk4IgPc5H6GTM/u7SGfJHpkmQAvtxCKqBGyDJ80rJac+fWNS26eyiZNbG4Nx68SueLhkXOKl+rXgwL24mI4q5gb9A4p0yr6FnYEUrmtlWS4RySHTMzdbr3H761Cr/L1tIhHP936ZFlqu2Q3FLJp1M5w0064VqY2bk38+Zn8sZp7lLYm1QuxGHqzkAU9w5FnyxjThd5cLT+6rFSieHZC6t41+GRlny//FBVrccdUMgyVW+SfBhni1vGV1lcrYZiiSGazm/rXIGSRlOq+WIJ+SKD26DOnYgwPtCHoMeByaCx51KC9tDzQ0ydinJhh1qZJWxQ6JlWpoLuuhkzZxdiWN/I4T06JRkO79x1FfctnXsKA277Fr+9mjAuJZFUDoyZ43EHGk+pGrFir5oP3LwLJcY65u5W0BhVVYOIHiCiC0Q0Q0SP1vj9zxDRm0R0loh+SESTxl9qb6FnYYcky2x/obE1cMw889YKLAS8S45X1gvv3HW5ZaqK+0J0qw0SkCKZbRZSbYesLB4xL/a2nsPHiBV71fzuLx7GZ993xLDPJ2gvTYs7EVkBPAbg/QCOAvgoER2tetqrAI4zxo4B+CaAPzb6QnsNrQs7SiVmqv57cNSLizWWZf/w/CrumBzEYIvXpUdzt1stcNosW4t7JF12fyixWAjDPqfqzp3LUAdGjHVYaWG0zpIRo1bsCXYuajr3EwBmGGNXGGM5AI8DeFj5BMbYs4wxHr/3AoAJYy+z9+Dyg9riHs/kUdzmXBklh0Z9mAunNw3ULMcyOLcYx7uP6LNAKtHjlgGkOyBlcWeMYT6S3nKYytEyyHRpdQN2K5mqQdebUjVqUYdg56KmuI8DmFN8PC8/Vo+PA/jHVi5KoF2W4QukzZBlgEoMweXVZPkxPpX6nhta09ulz++D1UKY0lhIq1ftRVJ5pPPFupn9WiIILq0ksG/Ia2pAVL0p1VQbZBnBzkLNd2Wt05Oam2GJ6NcBHAfwJ3V+/xNEdJqITq+tram/yh5E68IOM9MJgdqOmWfOr2BisM+QaNgbdvnx2h/+YvnvUYunakn2fGRz1G81Wjv3A6Pmxt7Wm1LNiM6951FT3OcB7FF8PAFgsfpJRPReAP8WwEOMsZqtD2PsS4yx44yx48PDrR2wdTs8+VBtMqQZuTJKJgNuOKyWsu6eyRfxs5l1vOfIiGHuCq1pkvzPJBTFfaHJtq1RvwuRVB65wtYkSSXpXBGz4RQOmai3A/WnVHnnbsSyDsHORE1xPwXgIBFNE5EDwEcAnFQ+gYhuA/BXkAr7ao3PIdCI1iXZFVnGHM3dZrVg37AHl+QAsecvh5DJl/BunZEDRlEty5Q3MDXQ3AFgbaOxNHN5bQOMSQfJZsI79+q7jYoVUoyy9CpNv/KMsQKARwA8DeAtAN9gjJ0joi8Q0UPy0/4EgBfA3xPRGSI6WefTCVRSWdihtnM3J1dGycFRHy7JnfsPz6/A7bDirumAadcDAF6XDUmFHr0QTcPntJW3XVUz4le3kYn/Ow+ZXNzrde6ZsuYuOvdeRdVXnjH2FICnqh77vOLX7zX4unoevrBDbeceTubgNyFXRsmhES+++9oiUrkCnnlrFW8/MGRYtolePDU69/HBvrpSUbOkRc6lFe6U0Z5yaSR8SrV6qpYfsArNvXcR92wdjJaFHesbWQRNkmQ4XKJ48jVpj6QRLplW8Tk3WyHnI6maHnfOSLkTbty5X1zZwPSQx/RVavWmVNN56cxAFPfeRRT3DkbLwg4zB5g43MnyVz+5DAC4/7D5xd0rxzjk5VV79aZTOUGPE1YLNe3cZ1YTOGjyYSqn1pRqWu7cediXoPcQX/kORkvsb2gjZ1rGCYc7Zi6vJXFsoh8jJm9/BzYnQ8bSeSQyhbo2SEBamD7kdTTU3DP5Iq6HU6YfpnJqd+7Sog6RA9O7iOLewWhJhgwlc9u6O7UW3DED6Fun1w68CtdRxQbZeBCq2UamslOmkzv3vHGLOgQ7E1HcOxi1nXupxBBJmQWKkpgAAAs7SURBVC/LANIkKQC8x4DIASNQJkOWB5gaaO5A80EmbvfsmM7d70Qis3lKNZUzblGHYGciinsHo3ZhRywt5coETcqVUfK+G8dw3+Fh3Ljbb/alAKgU92S2gIVo4wEmTrMIgkurCdgshCmTnTKcWg4fIxd1CHYmwgTbwfhVyjJ8MbbZsgwAfPDYLnzw2C6zL6MM19wT2QLmI2m47JamdzgjPidCyRzyxVJNN8zFlQ1MDXlMtZ0qUXrdp4akNxwj96cKdiad8d0pqInPVVnY0Qizc2U6GT7pm8wWylG/zQ4ZeSdcr3ufWd0wfXhJSa0p1bSQZXoeUdw7mEqme+PuPSSPyneCLNNpKFftSTbI5qmS9aY+AdkpE0qamuFeTa3rzYgD1Z5HFPcORm0yZCfJMp2Gp+pAtZENklMvrwUArqwlUWLmxw4oqTWlmsoVxQBTjyOKewejtnPvhFyZToV37quJLCKpfNPDVKBx584zZTrFBglUplSV18t97oLeRRT3DkZtMmRoI2t6rkynYrUQ+uxWXFiWinIzGyQABL1OWAhb8loAyQZptRCmhzrDKcMZ9bu2aO7CLdPbiGrQwajdxiQNMAm9vR5el61c3NV07tKUqrNmBMHFlQSmgu6OeyOt9uaLzl3QWd+hgk1UFnY069w7Y4CpU/E5bViWC5+aA1VAGgxaqREeJjllOkeS4SinVBljYkJVIIp7JzPglor7fDjV8HnhpPm5Mp0MP1R1WC0YVnmHM1pj8XQmX8S1UNKQtYFGw6dU07kisoUSGANcorj3NKK4dzA+lx13Tg3in84tN3xeJ+TKdDL8UHX3gAsWi7ogrRG/c0vs79V1ySmjdY/rdlCeUk1kkM6J/akCUdw7ngeP7cbFlY1Ni6eV8FwZ4XGvD+/c1dggOcM+F0LJHArFygAZ/xp0SqaMktHyBqksUnm+P1UU915GFPcO5/03jYEIePLsUs3f57kyQnOvDz+Yrrc3tRajficYq+ymBSS9vROdMkDtzl1MqPY2orh3OCN+F+6aDuDJs4tgjG35fTHA1ByPUypyWjr3WoNMF1cSmAy64bR1XtFUdu68uLvF/tSeRhT3HcAHj+3GlbUkzi9vlWZE9EBzvE7pYFqNx51Ta5Dp0uoGDnXQ8JIS5ZRqOi80d4Eo7juC9980BgsB36shzYjQsOaUZZkWOvdsoYjroc7ZvlSNckq1XNwd4se7lxFf/R3AkNeJe/YP1ZRmhCzTnP4+qXPfG1SvuQ95HSCqdO5X15MollhHOmU4fEqV70/tswtZppcRxX2H8MFju3AtlMK5xfimx0MbIlemGR+6bRx//Zt3Yle/+s7dZrUg6HGWIwgu8u1LHehx52zt3IUs08uI4r5DeODGMVgttMU1E06KXJlmeJ023H9Y+05XZRjXzEoCFkJ5R2wnwjv3VE5YIQWiuO8YBj0O3HtgCN97fbM0sy5yZdrGqL+S13JxZQNTQU9HOmU4wz5pSjUiS3XCCtnbiOK+g3jw2C7MhdM4Ox8rPxbeENED7WLEV8lrubSa6NjDVM6oXzoEvh6S4iqEW6a3EcV9B/G+o2OwWwnfe70izYSTIjSsXYz6nQhtSL7xa6FUR2W414LbN6+HUrBZSEh1PY746u8g+t12vOPgML53dqkszYSSWeGUaRPDfhdKDDh1LSw7ZTq7c+f2zWuhpOjaBaK47zQePLYLC9E0Xp2LyrkyeTHA1CZGfdLr+tzMOoDO2r5UC+XglXDKCFQVdyJ6gIguENEMET1a4/ffSUSvEFGBiH7F+MsUcN57dBQOqwVPvrYkcmXazIisYf9sZr3jnTJAZUoVEDZIgYriTkRWAI8BeD+AowA+SkRHq542C+BjAL5m9AUKNuN32fGuw8N46vUlrPPoASHLtAXeCb+5FMdk0NPx7hM+pQqIw1SBus79BIAZxtgVxlgOwOMAHlY+gTF2jTF2FkCp1icQGMuDx3ZhOZ7B999cASByZdrFkNcJIoCxzh5eUsIdM6JzF6gp7uMA5hQfz8uPaYaIPkFEp4no9Nramp5PIQDwnhtG4bRZ8NUXrgMQuTLtwm61ICBP/nb6YSpHdO4CjpriXmt1zdbsWRUwxr7EGDvOGDs+PDys51MIUJm4XIxJAzZDQpZpG1x378S9qbXgnbuYThWoKe7zAPYoPp4AsNieyxGo5cFbdpV/PSg697bBO+EDO0SWGZavt9PPBwTtR01xPwXgIBFNE5EDwEcAnGzvZQma8e4jI+izW+F32WC3Ckdruxj1O2EhYP/wzijuZc1dFPeep2kmKGOsQESPAHgagBXAlxlj54joCwBOM8ZOEtGdAL4NYBDALxHRf2SM3djWK+9x3A4bPnhsF2ZWN8y+lK7mXx7fg+kh747phLnDR8gyAlWBz4yxpwA8VfXY5xW/PgVJrhFsI//rh29GsaTr+EOgkuNTARyfCph9GarhU6ouUdx7HpHmv4MR2SGCanjnLmQZgSjuAkEX0d9nx2ffdxjvu3HM7EsRmIwo7gJBF0FE+NT9B8y+DEEHIO7rBQKBoAsRxV0gEAi6EFHcBQKBoAsRxV0gEAi6EFHcBQKBoAsRxV0gEAi6EFHcBQKBoAsRxV0gEAi6EGLMnGwSIloDcF3nHx8CsG7g5XQz4rVSh3id1CFeJ3W083WaZIw1XYhhWnFvBSI6zRg7bvZ17ATEa6UO8TqpQ7xO6uiE10nIMgKBQNCFiOIuEAgEXchOLe5fMvsCdhDitVKHeJ3UIV4ndZj+Ou1IzV0gEAgEjdmpnbtAIBAIGrDjijsRPUBEF4hohogeNft6OgUi+jIRrRLRG4rHAkT0AyK6JP9/0Mxr7ASIaA8RPUtEbxHROSL6tPy4eK0UEJGLiF4iotfk1+k/yo9PE9GL8uv0d0TkMPtaOwEishLRq0T0pPyx6a/TjiruRGQF8BiA9wM4CuCjRHTU3KvqGP4GwANVjz0K4IeMsYMAfih/3OsUAPwuY+wGAHcD+JT8PSReq81kAbybMXYLgFsBPEBEdwP4zwD+TH6dIgA+buI1dhKfBvCW4mPTX6cdVdwBnAAwwxi7whjLAXgcwMMmX1NHwBj7CYBw1cMPA/iK/OuvAPjQtl5UB8IYW2KMvSL/OgHpB3Ic4rXaBJPYkD+0y/8xAO8G8E358Z5/nQCAiCYAfBDAf5U/JnTA67TTivs4gDnFx/PyY4LajDLGlgCpqAEYMfl6OgoimgJwG4AXIV6rLchSwxkAqwB+AOAygChjrCA/Rfz8Sfw5gN8DUJI/DqIDXqedVtypxmPC7iPQDBF5AfwDgP+JMRY3+3o6EcZYkTF2K4AJSHfNN9R62vZeVWdBRA8CWGWMvax8uMZTt/112mkLsucB7FF8PAFg0aRr2QmsENEuxtgSEe2C1IH1PERkh1TYv8oY+5b8sHit6sAYixLRjyCdUQwQkU3uSsXPH3AvgIeI6AMAXAD8kDp501+nnda5nwJwUD6JdgD4CICTJl9TJ3MSwG/Iv/4NAN8x8Vo6AlkP/X8BvMUY+1PFb4nXSgERDRPRgPzrPgDvhXQ+8SyAX5Gf1vOvE2Psc4yxCcbYFKR69Axj7L9DB7xOO26ISX6H/HMAVgBfZoz9kcmX1BEQ0dcB3AcpjW4FwB8CeALANwDsBTAL4FcZY9WHrj0FEb0dwE8BvI6KRvoHkHR38VrJENExSAeBVkhN4DcYY18gon2QjAwBAK8C+HXGWNa8K+0ciOg+AP8zY+zBTniddlxxFwgEAkFzdposIxAIBAIViOIuEAgEXYgo7gKBQNCFiOIuEAgEXYgo7gKBQNCFiOIuEAgEXYgo7gKBQNCFiOIuEAgEXcj/D6jH2ZPA3LvTAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAD8CAYAAACMwORRAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAIABJREFUeJztvXl0XOd55vm8taM2AFXYSIAEwF2URG0UJUteJNuJZVuR7HTSbWcyJ0574unYOvEcZ5zI6W6n2z2ZmU5mkpwZa5K4e5x4OrYVx7FlWlYiO5a8yVpISRQlSlzADftWO2pfvvnj3q/qolDLvbdu4Raqvt85OiKKRfCyALz13ud73uclxhgEAoFA0F1YzL4AgUAgEBiPKO4CgUDQhYjiLhAIBF2IKO4CgUDQhYjiLhAIBF2IKO4CgUDQhYjiLhAIBF2IKO4CgUDQhYjiLhAIBF2Izay/eGhoiE1NTZn11wsEAsGO5OWXX15njA03e55pxX1qagqnT582668XCASCHQkRXVfzPCHLCAQCQRciirtAIBB0IaK4CwQCQRciirtAIBB0IaK4CwQCQRciirtAIBB0IaK4CwQCQRciirtAIOhJXr4ewRsLMbMvo22I4i4QCHqSf/fEG/jP/3Te7MtoG6qKOxE9QEQXiGiGiB6t85x/SURvEtE5IvqasZcpEAgExrISz2B9I2f2ZbSNpvEDRGQF8BiAXwAwD+AUEZ1kjL2peM5BAJ8DcC9jLEJEI+26YIFAIGiVXKGEcDIHh7V7xQs1/7ITAGYYY1cYYzkAjwN4uOo5vwXgMcZYBAAYY6vGXqZAIBAYx9pGFgAQTuXAGDP5atqDmuI+DmBO8fG8/JiSQwAOEdFzRPQCET1g1AUKBAKB0azGMwCkDj6VK5p8Ne1BTSok1Xis+q3OBuAggPsATAD4KRHdxBiLbvpERJ8A8AkA2Lt3r+aLFQgEAiNYTWTLvw4nc/A4TQvIbRtqOvd5AHsUH08AWKzxnO8wxvKMsasALkAq9ptgjH2JMXacMXZ8eLhpHLFAIBC0Bd65A0Ak1Z2HqmqK+ykAB4lomogcAD4C4GTVc54AcD8AENEQJJnmipEXKhAIBEZR3bl3I02LO2OsAOARAE8DeAvANxhj54joC0T0kPy0pwGEiOhNAM8C+CxjLNSuixYIBIJWWI1Xinu3du6qhCbG2FMAnqp67POKXzMAn5H/EwgEgo5mJZHBnkAf5sJphLrU6969Jk+BQCCow2o8i/3DXlgt1LWduyjuAoGg51hNZDHmd2HQ7UA4mTf7ctqCKO4CgaCnKBRLCCWzGPE5EfDYEenVA1WBQCDoJtY3cmAMGOadu5BlBALBTud6KInnZtbNvgxTWU1IHvdRnxMBj0N07gKBYOfzlz++gke+9orZl2Eq3AY54ndh0OMQB6oCgWDns5EtIJLKI5PvzjwVNfABphGfEwG3A5FUHqVS94WHieIuEPQQaTkkSznE02usyNEDQ14nBj0OFEsMiUzB5KsyHlHcBYIeIp2XithKItPkmd3LaiKLoMcBh82CgMcOAF15qCqKu0DQQ/DOfSXeu8V9LZHBsM8JABh0OwB0Z76MKO4CQQ/Bs8uXY71b3FcTWYz4XQCAgEcq7t3omBHFXSDoIfhBqjIVsddYiWcwWt25C1lGIBDsZNL53pZliiWG9Y0cRvxScRedu0Ag6ApSPa65h5M5FEsMIz5JlnE7rHDYLKJzFwgEO5uyLNOjVkj+pjYiyzJEhIDbgXAXxv6K4i4Q9Aj5Ygn5ojSs06ud+1qiMp3K6dYpVVHcBYIegevtIz4nkrkiNrLdN7jTDJ4rwzt3AAh6HMIKKRAIdi4ZWW+fCnoA9Gb3zuWoYUVxlzr37st0F8VdIOgR+GHqZNANAFjpQa/7SiKDAbcdLru1/FjAbRedu0Ag2LlwWWZqSO7cezCCYDWe3STJAFLnHkvnUSiWTLqq9iCKu0DQI6S2yDK955hZTWTLNkgO97pH090lzYjiLhD0CNwGOexzwuOw9qTmvpao0bm7u3OQSRR3gaBH4J17n92K0X5Xz3ndGWNYTWQ22SCBSufebbq7KO4CQY/ANfc+hwWjPlfPde6RVB75IqvfuXeZ110Ud4GgR+BWyD6HDaN+Z88dqJY97v7Nxb3SuQvNXSAQ7EBSOWloqc9uxajfhZV4Fox133q5enAZarRKlhlwSws7ROcuEAh2JOm8ZPVzO6wY8buQK5QQ7cLhnXpU58pwXHYrPA6r0NwFAsHOJC137k6bBaOyNNFL0kxlMbZry+8Nehy96ZYhogeI6AIRzRDRozV+/2NEtEZEZ+T//gfjL1UgELRCOl9En90KIipLE73kdV9LZOFz2tDnsG75vYDHgVCXFXdbsycQkRXAYwB+AcA8gFNEdJIx9mbVU/+OMfZIG65RIBAYQDpfhFsubKM+Xtx7qXPPbDlM5Qy6uy8ZUk3nfgLADGPsCmMsB+BxAA+397IEAm186muv4M9+cNHsy+hoUrliOVOFF7nVHiruK/Gt06mcQBcmQ6op7uMA5hQfz8uPVfMviOgsEX2TiPYYcnUCgUpevhbB2fmo2ZfR0WQUnbvLbsWA295TskzTzr0HizvVeKzaP/VdAFOMsWMA/hnAV2p+IqJPENFpIjq9tram7UoFggbE0nkks0WzL6OjSeWKm/TmXhpkYozVDA3jBDx2JHPFckRDN6CmuM8DUHbiEwAWlU9gjIUYY7wF+C8A7qj1iRhjX2KMHWeMHR8eHtZzvQLBFnKFEtL5IhI9uHxCC2mFLANI0kyvFPd4uoBsobTF484Z5OFhXWQNVVPcTwE4SETTROQA8BEAJ5VPIKJdig8fAvCWcZcoEDQmnpF+IJOiuDdEKcsAKA8y9QJ8OnW4Xufu7r58maZuGcZYgYgeAfA0ACuALzPGzhHRFwCcZoydBPA7RPQQgAKAMICPtfGaBYJNxOSo1l5cG6eFVK6I3QPK4u7E2kYWxRKD1VJLfe0eGnncgUoEQTc5ZpoWdwBgjD0F4Kmqxz6v+PXnAHzO2EvrDeKZPK6uJXHLngGzL2XHUi7uGVHcG5HOV2nufheKJYZQsr6LpFvgnftonQPVbkyGFBOqJvPfnr+OX/3L55Hvsi0w2wkv7rliCdlC9xyIGU06Jw0xcbj+3AvRv1x+qo775Qx2YecuirvJLMcyyBVLSIiuUzdxxQYd4ZipD59Q5VSmVLv/UHU1noXbYYXXWVusGOiTwsNE5y4wDN4pJDLdc0q/3cQ2FXfxJlkLxtimCVWgIlH0wqHqaiJT1wYJADarBf199q7yuovibjKV4i6Kkl5iCvuaeB1rky2UwBjgUhT3Ia8TRD3SuSeydSUZTsDjQLjHrJCCNhKRFwTEReeuG+VrJxwztUnLizrcClnGbrUg6OkNr/tqvHHnDgCDbtG5CwxEdO6tI2SZ5qTKK/Y2JyKO9sgg02qiuSOo2/JlRHE3GVHcWyeWzsNulXzaYkq1NmnFij0lvTDItJEtIJUr1rVBcgbdorgLDCKdKyIjb8cRB6r6iaXzGOuXujLRudeGZ6Yo3TKA1LmvdvnCDp58WS80jCNp7rmuWT0oiruJKD21onPXTyxdwPhAHwAxyFSPVK5ecXdhfSPX1XMWZY97E1lm0ONArlAqv1Y7HVHcTWRzcRedu17i6Tx29cvFXXTuNUnX1dylgreW6F5pht+ZNDtQ7bZ8GVHcTYQ7ZQDRubdCLJ3HgNsOj8Mqinsd+P7UWrIM0N12SP7G1cwK2W1TqqK4mwj/JrKQKO56KRRL2MgW0N9nh9dl6yhZ5qeX1vCDN1fMvgwAlc7dXdW5j/TAur2VeAZOmwV+V+MorYCnu6ZUVQWHCdpDVC7u44N9wueuE/6m2N9nh9dpw0auc4r7//3MDGKpPH7h6KjZl1LR3OvIMt3smJEGmJwgapx8OegWnbvAIMKyLLNn0I14B3WcOwnucfe75OLeQa9jOJnrGCcKt0K6qmSZoMcBq4Xa3rl/58wC3liItfXvqMdqPFteCN6ISjJkdzRaoribSCSVg89lw6DbIQ5UdcKLO5dlOskKGU7mEEnlkSuY70TJ1JFlLBbCiM/Z1s6dMYZH/+F1/NVPrrTt72hEo92pSvwuOyyErplSFcXdRCKpHAbdDvhcNqG566Rc3N12eBy2jjlQLZZY+fZ+bcN8ySOVK8JmIditW3/kR/yutt5hrG1kkc4XMRtKtu3vaIS0O7V5526xkDTIJGQZQatEUnkMenhxF527Hqo7904p7rF0HnwWphNshtWLOpSMtTmCYDaUAgBcD6fa9nfUI52TduvWW69XTcDjEJ27oHUiyRwG3Xb4XHZk8qWuHiRpF5uKu7Nzins4WSnoqx3gRKle1KGk3REEs3JRj6bym3KAtoPKBiZ1m6YGuyhfRhR3E4mkcgjIsgwg7JB62FLcM4WOGB8PbVQKxGqHd+6jfhdi6XxZlzea66FKxz4b2t7uvbI7VWXn7nYIt4ygdaKpPAbcDvhckr9WSDPaiWfycNgscNmt8LpsKJQYsh1wgKns/jqiuDfo3Hnha5c0MxdOgbsQr4e3V3dfUZkrw5E69+74ORTF3SRyBWn4RpJlROeul3g6D7/85shXqHWCNBOSi7vVQljrADtks84daJ/X/Xo4hZt290u/3u7OXWWuDCfgsSOSyqFUMv/ur1W6qrgXiiV8+vFXcfpa2OxLaQofYOIHqoBY2KGHWDqP/j7p9ePFvRPskLxznx7ydMQC6nSuuMUGyWn3LtXZcAo37PJhyOswRZaxWwmDbruq5w+6HSiWWFc0Wl1V3H82s47vnFnEP76xbPalNIXbrQbdjnLn2Q3fUNuNVNyl18/j7Jw7oHBSmmHYPdDXEbJMquGBavtkmVSugLVEFpNBD/YG3Nsuy0i7U11Np1M55UGmLtDdu6q4P/HqAgDg2ro5flot8NCwQY+QZVpBWdx9HSTLhJM5BDwOjPicHWGFzOSLW6ZTOf19djhtlra8Cc2F0wCAPQE3poKe7e/c41nVNkigEh7WDY6ZrinuyWwBT5+TQpqu7oTiXrNz721ZZmY1gTNzUU1/plbn3imyDC/u6xtZ0zXcdL6+LENEsh3S+M79ujy4NBlwY2/QjaV4pm2unFqsJjJNNzAp4bG/3eB175ri/oM3V5DOF3Hn1CBmwykUOtwzrizuXtG5AwD+t6fO47N//5qmPxNLVYo7fx07oXMPJXMIysW9UGKm3+Y3kmWA9u1S5R73vQE3JoNuMAbMR7ave1ezO1WJkGU6kCfOLGB8oA+/esceFEoM85G02ZfUkGhK6tIH3HbYrRb02a0937nPR9KaCkypxJCQ436BTpNlslLnLh9Wmn2oKrll6ofAjvhdbbnG2XAKPpcNA2479gY8ALbPMZMtFBFN5VV73AFFpnubOvd8sYT/64eXtiVErSuK+1oii59eWsfDt+7GvmHpG+iqSTkWagknc3A7rGUd1OeyIZ42vyiZyVIsjXimgGxB3W17IlsAY4C/SpYxOxmSMSbLMs5yYTEzHbJYYsgVSo07d58Ly/GM4QNgs+EU9gbcICJMBt0Atq+4l22QGmQZj8MKh9XSts59OZbBn/7goijuanny7CKKJYYP3zaO6SG5uK91dnHnoWEcn8uGRLZ3O/dktlCOPV7fUPeDFedxv3JxdzusIDJfc09kC8gXmSzLyJ27iYeqlRV79X/cR/1OpHJFw+96ZkOpclEPehzwOKxlqaadbGQL+F++9yYAYHrIq/rPEREGPfa2de5LMelNfre887edqCruRPQAEV0gohkierTB836FiBgRHTfuEpvzxJlFHN3lx8FRHwKyb/xah3fukWQOg56K99bnsve05s6/6QFgXWUhVEYPANIPptdhQ8Lk4h6W35wCHkfZqWGmYyZdXtRRX5ZpxyBTUZZH9wSk4k5E2Bv0lA9Z28W19SQ+/Nhz+Oe3VvHvHzyKO6cGNf35QXf7plSXYpJcvHtA/TmAXpoWdyKyAngMwPsBHAXwUSI6WuN5PgC/A+BFoy+yEVfXk3htLooP3zbOrwP7hjwd75iJpPJbOvdeXtixrCjuagthdXEH0BGr9vgtfcDjQJ/DCp/T1hnFvYEsw6ULI0POVuIZ5IolTMpaOyC5ZtqZDvnji2t46Is/w9pGFv/fvz6Bj799WrXHnRPwtC9fZjEqvb58oXs7UdO5nwAwwxi7whjLAXgcwMM1nvefAPwxgG0VF594dQFEwEO37i4/NrUDinu0Spbxu+w9faC6GKscgK+rzD+vWdydNiRNXrWn7NwBYNjvNFVzr7c/VckY79wNvE6ure+VO3cAmAy6MR9Oo2iwNZQxhr/88WX85l+/hN0DffjuI2/HvQeGdH2uwTbG/i5G0/C7bOXzoXaipriPA5hTfDwvP1aGiG4DsIcx9mSjT0REnyCi00R0em1tTfPFVsMYwxNnFnDP/uCmSM+poAcL0fS2+mm1Epbjfjm9vrBD2bm3Utw9TvNfRz4Aw4v7iM9pqlsmJb/ZNe7cjZdl5uQOnWvuALA36EauWMKygXcI6VwRv/P4Gfzv/3ge7795F771yXvKUpAeAm1c2LEUS2+L3g6oK+617mnKb7tEZAHwZwB+t9knYox9iTF2nDF2fHh4WP1V1uHMXBTXQyl86NZN7zXYN+wBY5Vvrk6jUCwhnimUbVcAen5hx1IsjSGvdF7Siizj64BVezw0LOjlxd3VEQeq9SZUAemOx+u0Gep1vx5OwmYh7Orf3HgBMEx3X4im8S/+4ud48uwifv+BI/jiR2+Du8HZghoGPQ7E0vm2zMosRjObXo92oqa4zwPYo/h4AsCi4mMfgJsA/IiIrgG4G8DJ7ThUfeLVBThtFjxw09imx/k30JUOlWaiclHarLn39sKOpVgGu/r7MOxzanLL2Cy0SW7ohFV74WQWLrulXGRGfJIsY1bOfL39qdWM+I29w5gNpzE+2AebYrUfl2iMiiH4zN+dwVw4hS9/7E789n37NevrtQh6HGAMbVksshRLY1cHde6nABwkomkicgD4CICT/DcZYzHG2BBjbIoxNgXgBQAPMcZOt+WKZfLFEr57dgnvPTpazkPnTMl2yE7NmFEmQnJ6PV9mKZrBWL8LQ171WSyxdB7+PvumH+hOOFCVplMr3uoRvxOZfMk0F0+q7JZpXNy5190oZkPJTXo7IFkA7VbCNQOK+0tXw3jxahif+cVDuP/wSMufj9OufJl0rohIKo/dndK5M8YKAB4B8DSAtwB8gzF2joi+QEQPtfsC6/GzS+sIJ3P4cJUkA0i36UGPo2MPVbnNarPm3tv5MkuxNHb3u+TOXX1xV0oyADpi1V5EzpXhmG2HVOOWAYyPIJgNp7Zo31YLYWLQjVkD0iG/+OwMgh4HPnLn3pY/lxKeL2N0cec2yO1wygCAKnGKMfYUgKeqHvt8nefe1/plNefbry5gwG3HOw/V1u6nO9gxo8yV4fRy584HmMb6+0BE+InGzl0JL+6MMUNu0fUQTuY23ZWVB5niWewfVj9QYxSVIaZmxV2KIDDitYtn8oik8piscbC5N+BueUr17HwUP7m4ht974HDTf5dW+PyJ0XZIPsuxaxs87sAOnVDdyBbw/TeX8eCxXXDYav8TOtkOWUuW4cmQvbiwo/xN3+/CkNeBRLagyukUr9W5u2woMSCTN+/sgoeGccyOIFDbuY/4XcgVS+Xco1aYrWGD5EwG3ZgNpVo6g/jiMzPwu2z47++e1P056lEODzN4kGkxKg8wbVPnviOL+/fPLSOTL21xySiZHvJgNZE13TlRi9qyTO927suK4s4lDDXSTC1Zpryww8Qoh3CVLMM7d7NkmZTK4m6k172cBhms3bknsgVEdL6JXFhO4PtvruBj905vOW8zAn5H3a7OfaxTNPdO5NuvLmBisA93TNYfKy5nzBjUvf/Bt1/Hv3/iDUM+VzSVg9Nm2fTDVu7c23BC3+ksKrTIIa96fVq5Yo/jK2e6mzPjkMkXkcoVNxV3f58NjjYtw1B7TU6bBRZLY6mF554rZw70ooz6rWayRTvkY8/OwOOw4jfvmdJ9fY1w2a1wO6xt0dyDHkdDS6qR7LjivprI4LmZdXz4tvGGuiAv7kZlzPzk4hqeeHXBEO+rNMDk2HT9ndS5X1nbwF8/d3XbFkzwYjLa71R07o1/sBhjiGcKdTt3sxwzZY+7orgTkTzIZJIs02BRhxLeUS4ZUNyvh1JyztPWzpoPNekJELu6nsSTZxfx63dPbpI1jWbQbfyU6mI0s216O6DyQLWT+O5rSygx4OEGkgxQ8bobkQ5ZKJawFMugWGI4txjHLXsGWvp8kVR+yzdmpyzseOb8Cj799TNIZAs4NtGPOyYDbf87+QCT02ZV3bknc0UUS6ymWwYwT5apjh7gjPicWFPpAjKaZos6OGN+F6wWwoIBuxDmajhlOLyb13Oo+hc/moHdasHH3zHd0vU1I+Axfkp1KZYu37VsBzuuc3/7gSE8+v4jODDS2HXQ57BiV7/LkFx3XtgB4OeXQy1/Pinud3NRMnthB2MMX3zmEj7+ldMYH5QOfF68Gt6Wv3splil3jXyqs5nmzgdM/K7axd0sWYYXBP7v4AybGEGQzhfhUtG526wWjPldWIi2Xtyvh5M1nTKAJHuM+V2ai/tCNI1vvbKAj9y5R9N2JT20I19mKZrZNo87sAOL++ExH/7Nu/areu5U0BjHzJy8FsxCwPNXjCruW28pzcqXSWYL+ORXX8H/8f2LeOiW3fj2J+/FwREvXtqm4r4sT6cCgNNmRX+fvWnnHkttjR4AlKv2TOrck9J1V399zYwgSOfUyTIAMD7Q13Lnni+WsBjN1NTbOXuD2r3uf/XjyyACPqHy578VAm67oZ17IpNHIlvYtlwZYAcWdy1MD3sMmVKdlze4v+vQME5dDSNXaE13j6bym7LcOWYs7LgeSuKX/5+f4+lzy/i3H7gBf/6vbkWfw4oT0wGcvhbZll20i9H0prwNNYNMtXJlgErnvmFS5x7a4Jr75u0/Iz4nYum8KWF2aZWyDACMD/a13LkvRaU73VpOGc6kRq/7aiKDx0/N4Zdvm8D4NhRIqXM37mex4nEXxd0QpoMeRFL5sq9cL3ORFCwE/PLtE0jnizg7H9X9uUoltiXul7PdCzt+emkND33xOSzHM/jKvz6B33rnvvIh74npADayBby1lGjrNfABJuXU3pDXoV6WqVfcTTq7CCdzsFkI/ioXD89LV2uH/NJPLuMHb64Yck3N9qcqGR/ow3I809Kb+nW5I2/UuU8G3VhNZMuJlc34rz+9ikKxhN++r/1dOyBNqW5k1a98bEbF4y5kGUMwyg45F05hV38f3n5gCESt6e7xTB4ltvW2HdjehR3/7flr+I0vv4QxvwsnH7kX7zi4edL3rukgAODFq63LUI1QDjBx1OTLxOt07i67BVYLmTbfwKdTq51cWtbtFUsM/+f3L+IvfjRjyDVJnbu6H/XxwT4US6yljJnZGlG/1eyVDxbVOGYiyRz+9oXr+KVbdpdzo9pNZVG2Md276NwNZsqo4h5JY0+gD4MeB24Y8+P5Foo7987WkmW2a2HH6/Mx/Ifvvol3HRrGtz55T80T/LF+FyaD7rbr7ss1BjvUJEOWZZmqg2kigsdhNS1fpno6lVPJl2leNK+HksgWSjg7HzPkTSqd1yDLyMWnFd19NpSCw2bBaINDz0kNjpm/fu4qUrkiPnX/Ad3XpJUJ2VRglJV6MZqGhYBRn/pl3a3S1cV9b8ANC7WeDjkXTmHPoPTN+Lb9Qbw8G9GtnfKpvAGTDlRzhRI++83XEPQ48Of/6raGG2FOTAVw6lq4rX738k7JTbKMExvZQnlsvhbxTB4WArw15AYz99FWT6dytMgy55clKaxQYnj5eqTla0rlNMgyclFrRXefDaewZ7Cv4dBU2evepLgnswX8zc+v4X03juLQqE/3NWnlyJgfgDQNawSL0QxGfK5N8cftpquLu8NmwcSgu6Vc90y+iNVEtuzZvWd/ELlCCa/M6vuh4/p/oG5xb2/n/hc/uozzywn80Ydv3tL1VnNiOoBIKo9Lqxttu54lxQATR00EQSydh89lr1lAPE6rabJMdSIkJ+hxwkLqZJnzS3FYCLBZCC8Y4M7KbHPnfj2Uaqi3A1Jz43fZyvp8PU6+toh4poDfesc+3dejh1G/E/199vIbbatIOe7bp7cDXV7cAUl3b+XWal7+Jt8TkL7p75wOwELACzqlmbIsU6O4+9u8sOP8chxffPYSHrplN37h6GjT53Pd/aU26u5LsUx5gIkz7OVBW42Le7XezjEz9jdUp7hbLYSgV53X/fxyAtNDHhyb6G+5uDPGVE+oApIHfcjr0N25M8YwF25e3AEphqCZLPP1l2ZxaNTbMGqkHRARDo/5cGE5bsjnW4plti0wjNMTxf3qWlJ3Ah33uHNZxu+y4+aJAd2Hqjxxr54VEmjPlGqhWMJn//4s/C47/sNDN6r6M3sCfRjzu9o6zLQUS28JUlLbudct7i67KcU9Xywhls7XLO5AZSNTM84vJ3BkzI+79wVb1t1zxRKKJaYpFnd8oK/c1GglkpL83HtVTGJOBt0ND1TfWIjh7HwMv3ZirynxzUfGfLi4stHyBi3G2Ba773bQE8U9mSvqHv2el7/5JgYrncjb9gVxZi6q2salJJySrHLeGlp3Oxd2/JefXsXrCzF84eGb6hafaogId+0L4KWr4batiFMOMHF4BIHu4u4050CVpwjWOlAFeHFv/H24kS1gNpzCkTEf3rY/iEKJ4XQLunsmJ90FagmrasXr3igwrJrJoBsLkXRd2+VXX5yFy27Bh2+f0HUtrXJ4zIeNbEH3Gx0nksojWyhtq1MG6IHiXnbM6MyYmYuk4bBZypncAMo/dKeuaf+hi6ZqW+WASuceTxtbmGZWN/Bn/3wRD9w4hg/cPNb8Dyg4MR3AaiJryFq0WtTqaPjofqPDx6ayjAkHqlxyC3hqOyLUTKnyA7wju/y4Y3KwZd09lZdeB7WyDCBPqUbTug7SedJjIxskZzLgQaHEsBjdejezkS3g5JkFPHhsd92vc7s5MiYd4LZ6qGqGxx0p3Co7AAAgAElEQVTogeK+r8V0yPlIChMDm0/+75ySfuj0WCKlRMja36zt6NyLJYbf++ZrcDus+MKHbtR8e3vXtBQc1g7dvbKBafM3vd1qwaDb3rBzj9fYwsTxOG2mHKjWCw3jjPidCG1kyzlFtSgX9zEf3A4bbtkz0FJxV7uoQ8nEoBu5QgnrSe13u3PhzTJmI/gEa61D1ZNnFpHMFfFrdxm7Qk8L3J1zYaW14m6Gxx3ogeK+e6APDqsFV9f1dZ5z4TQmqm4x3Q4bbt0zgOcvr2v+fJFUvqYNElB07gZ2nX/z82t4ZTaKP/ylo7rClvYPexHwONqiu/NBmVoHTY0GmRhjiKe3xv1yfE4bNnKFtklJ9SjH/XrryzIlBoQaFM3zy3F4nbayz/rufYGWdHe1K/aUtOKYuR5KYcTnVPX38e6+1l3h1166jiNjPtzWYgJrK/hcdowP9LXsmKnYfUXnbihWC2Fv0I2r6/rsfHMRybNbzT37g3h9IaZ5LV40latpgwQqCYdGde7XQ0n8ydPn8Z4jIw23VjWCiHBiKtCWYaalaP3NNI0GmTL5EnLF0pYRf47HaQNjlQ1E2wXX3Ot17sOKXar1OL+UwOExX/kO6+59QRRb0N31dO6teN1nVTplAGDU54LDZsFs1V312fko3liI49fuMucgVckRAxwzi9EM7FYqnyVtF11f3AEpHfKajs49kckjmsrXzKW+e38QJQac0lj0wsnaoWGAsW6ZUonh9//hLOwWC/7owze39ENy174A5iNpQ6JgldQaYOI06tzrhYZxKsmQ2yvN8NCwgTrXVZlSrX9Hcn45XtZ6AbSsu/POXZPmPqi/c58NpxoGhimxWKjmsuyvvTiLPrsVH7pNX0NiJIfHfLiylmwpLHAplsao39V0E5bR9ERxnx5y41ooqfmAaE5Og6ylH96+dxAOm0WTJZKx+qFhgLELO84uxPDClTB+74HDLe9sPNEm3Z1rkXx6U0mjZMimxd1pTnEPJ3MYcNvrTiE2W5S9FMsgnilsKu6t6u787kWLW8bvssPnsml+M8/ki1iON476rWYysNkOmcjkcfK1RfzSLbu2ZPWbweExHwolhstr+gf5lqKZbY365fRIcfciWyhhSWMYUtnjHtj6hXHZrbhj76CmQ9VEtoBCidUt7kYu7OCZLbftbX3448iYHz6XzXBpZimWqbtTcsjrRCpXrKk1qy7u2+yYqRc9wOGdez1Z5rx8+39kl3/T463o7hkdmjugL9d9PpIGY+qcMpy9stedn49858wiUrkifu2uSU1/d7swIoZgMZbedr0d6JHiPjUkfbNptUM2O/m/Z38Qby7FVW9siSZ5rkz9jsSofBluyzNC57NaCHdOBQw/VG00kj3UYCNTp3buoWS2rscdkBqC/j57XTskj1c+PLY5Q4Xr7qeuaX/9ueauRZYBpOAsrZ37nAaPO2cy4EZKnkNhjOFrL87ihl1+3DLRr+nvbhfTQx7YLKT7ULVUYliJZ7bdKQP0SHHfNySt5NO6cm8+kobXaatbjN+2X1ssbrjJgRtg3MKOkFwU6+n7WrlrOoAra0nVeeRqWI5lMOav/U3faEq1WXH3mCjLNBsQG/HVP0u4sJzA+EDfFjnijslB2K2EF65oL+4pHQeqgL7OvTLApD6Wd1K2Ks+GUnhtPoY3lzrjIJXjsFmwf9ir+1B1fSOLfJGJzr1djPqd6LNbdXXuE4N9db/Rjk0MwO2wqtbduZuinhUSMC7RMJTMwee0bcpsaYWK7m5c974Uy2B33c69/uFjs+LOD6bNkWUa3ymN+OtHEFQfpnLcDhtumdCnu+uxQgLSoWoiWyi/1mq4HkrB7bCW77rUoIz+/fqLs3A7rPjQrbs1XWu7kTJm9HXui+V9BaJzbwtEhCkdAWJzkdSm2IFqHDYLjk8FVOvuUZWduxE+93AyV9dvrYebxvvRZ7cadqiaykmFo95hLz98XKthh+SLOnx1Dtx4557UEQ+hl1KJIZLKN5RlgPpTqtlCEZfXkjiyq3as7d37JOut1ruRdK4ICwEOjVGz4wPS972W7p3bILV03RODUiz3ucU4Tr62iIdu2V3362oWh8d8WIxlNL3RcZZkaWu7EyGBHinugOSY0bK0Q0q3S9c8TFXytn1BXFrdUBUIFZY193oTqoC0Ns6IA9VQMqs6Q0YNdqsFd0wOGqa7c6dMvaS8gMcBovqdu89pg7WOtYxr7tuZ6R7P5FEssfIGn3oMy/ky1QNWM6sbKJZY+QCvmrLfXaPuzhd1aJU59HjdZ8PJmrbhRjhsFuzq78PXX5pFOm/uRGo9+N3URR2TqgvR+nbfdqOquBPRA0R0gYhmiOjRGr//b4jodSI6Q0Q/I6Kjxl9qa0wPeTAXTqmO0w0lc0jni03HqO+RdXc1emg0lYOF0NDi5TfoQDW00Vwi0MqJ6QAurCRa3kkLNB5gAgCb1YKAu/Yu1UbRAwDgtFlgt9K2au7l6VQVmnuuUNqSH8Rv+2+o07nfPjmgS3fXsj9VSWVKVd18CGMMs+FUWWbRwmTQjXS+iBt3+3HzeGccpCrhB9x6DlWXYhm47JaGJop20bS4E5EVwGMA3g/gKICP1ijeX2OM3cwYuxXAHwP4U8OvtEWmglJIkdqEt0qOe+Nv1ht3++Fz2lRJM5IP2tFwmMHnspdlh1YIJ3OatE813DUdAGPAaR2BadXwAaZGMahDXifW63TujcKkiGjb82UqoWHNO3dgq9f9/HICDpsFU3WicvXq7ulcEX0O7TfoUsa+RXXnvpbIIpMvqR5gUsKtk510kKpkfKAPPqdN16HqUiyN3f31z+3aiZqv+gkAM4yxK4yxHIDHATysfAJjTPmv9gDY3lAPFewblgPEVEozZRtkE1nGZrXgrn0BVTkz0VS+6Tu4z2lDtlBqaSKOMabKuaGVW/YMwGG1GLI0u7yByd+guPscNaOamxV3YPuTIUNNQsM49RZlv7UUx8ERb8M1bHp093SuCLdde+dORJpy3WfLPy/ai/sdkwGM+V14WGdERrshIhzSeai6GM2YorcD6or7OIA5xcfz8mObIKJPEdFlSJ377xhzecbBOyK1K/eql3Q04u59QVwLpcrRnvWINMiV4VQiCPR37/G0NCwVNDjLwmW34tY9A4Y4ZhoNMHGGvbWnVFUXdxM692aH2PV2qV6QF3Q0Qo/unsoX4dLolOFoyXW/uCJNcPIUVi38yh0TeP5z766546BTODzmw/nlhOYwuqVY2hSnDKCuuNe6n9jyL2SMPcYY2w/g9wH8u5qfiOgTRHSaiE6vra1pu9IWCXiknY3qO/c0Ah5HwwXSnHv2DwFAU0skl2UaUYn91V+YeOpgM/1XDyemA3hjMd5y4VxWsVOS58tU/0B1YnFvFhrGqRVBENrIYjWRrWmDVML97s9rkGYyuSL67Pp8ExOD6r3ur8xGEPQ4NA0wKelEOUbJkTEfEplC+Y5TDfliCauJrCked0BdcZ8HsEfx8QSAxQbPfxzAh2r9BmPsS4yx44yx48PDw+qv0gCISFq5p7K4z9dJg6zFkTEfAh4Hfj7TWJqJpvIINBkqMiI8LKRS/9XDiekAiiWGV1rYDgRInXu9ASbOsM+JTL6EZFW6YzyTb7rce7s199BGDl4VcwVepw19duumCILKgo7Gxb3PId05aTlUTeULcOs4UAUkrTmUzJWnXBvxyvUIbp8c7PgirZfDo9oXd6zEM2Bs+3PcOWqK+ykAB4lomogcAD4C4KTyCUR0UPHhBwFcMu4SjWN6yINLq+purebCqS057vWwWAhv2x/Ec5fX635uxhjCDULDOEYs7OD6r5E+d84dk4OwWkjXKLySpVim6U7JWoNM2UIRmXwJflfjguV12ZBQWdyfPrfcVFJrRjiZVTUNTERlOyTnrfKCjsayDCBJM28sxFR/f6RzRc3TqRy1dshwMocr60ncbkCOUafCvzZaHDPlJR2d2rkzxgoAHgHwNIC3AHyDMXaOiL5ARA/JT3uEiM4R0RkAnwHwG2274hY4MR3ESjyLmdXGCW/FEsNCNK1Kb+fcu38IK/FsXU0/nS8iVyipkGVaX9hRkWWMz4/2OG2YHvKUc1D0wAeYmskytSIImk2ncnwqD1Qz+SJ++29fxleev9b0uY0IqZhO5VQvyr6wHMeQ11H+9zZCa757Jl/SPJ3KKQ8yNSnu/C7ujsnuLe79bjvG/C5Njpnyej2TOndV92uMsacAPFX12OcVv/60wdfVFu47LElBz15YxcHR+rfAK/EM8kVW3oajBu53//nMOvYPe7f8fsUq17goGbGwg697MypXpppDo16cW9S/wEBtR1NelK3ocrlNtJHPHVAvyyxG0ygxYEWDllqLcDLX0PmjZMTv3NQBnl9ObAkLq8fte3nOTAj3Hx5p+vxUrtB6595Ed395NgKbhXCsQ8K+2sXhMR8urKiP/u34zr2b2D3Qh8OjPvzoQuPD3Dkdtq7JoBvjA314bqb2YVc0xRMh1bplWtPcfS7jcmWqOTjiw2w4VY6T1QofYGrmIhjyyYuydXTuXqcNyVyxaYY/t/o1W1zdDC3W0xGfqyw1FUtMlVOGo1V3l4aY9H0fjPqcsFoIC9HGg0yvXI/gxvF+TZnxO5EjYz5cXt1QPQi5FE3D57KZFqfQU8UdAO47MoxT18INnRRzfIBJQ+dORLhnfxDPXwnVXICs1k1hxMKOUDLXFqcM59CoD4yhqbxVDzUDTIAkK1loc+eupbgDzfNluOSwojHrXwljTNNrPuxzIpEpIJMv4looiWyh1NQpo+Su6SBen482PegslZgky+gsujarBWN+V8POPV8s4bX5KO7oYr2dc3jMh1yxpNpxtxjLmBI7wOm94n5oBPkiw3MNnC1z4RSIKrelarn3wBBi6TzeWtoqWXBZplGuDGDMwo6wwbky1RwclWSnS6v6dPdlFQNMgJQjH/A49HXuKlftzcvzDK107qmcdJ6ivnOvLO2oxA6o69wByRhQYs3fkDIFfYmQSpp53d9aiiOTL+H2SfMWWW8XWmMIGu0r2A56rrgfnxqE12nDjy6s1n3OfCSNUZ9Ls6zB891rvXFwWaaZWwYA/H2t5cuENnKGDzApmQpKCwwuadAflSyqGGDiSF73SpZNLKWxc29S3HlXmsgUVFn+aqE2eoAz4udTqhmcX4rDQsCBka3nNPX/vPS1bVbc9S7qUDLRJNf95R44TOUcGPHCaiHVdsilaMa0ASagB4u73WrB2w8M4UcX1uraFuciqaaxA7UY9btwYMSL52oMM/EC0KwoAXKmewsLO9otyzhsFkwPecpTiVpZjqVV73Wt3qXKXUTNDlTVJkMqu1I1yZ610DpXMOzlg0xZvLWcwPSQR5NePeqvHWFQjZ79qdWMD/ZhOZ6pqzO/fD2C3f0uU4vYduG0WTE95FHVuWfyRYSSOdMGmIAeLO4AcP+RYSzFMrhQJ8JzPpzSZINUcu/+IE5dDW/JhommcvC7bA2zQzitrNpjjCHShlyZag6N+nTLMpLHXV0xGPZu3lwUS+fhdlhhb/I6qpdl0oqpUX3STFi2nqrv3Lksk5EOUzVIMkBF1mkqy+T1bWFSMj7QhxKrSGnVvDobxe090LVzJMdMc6cYf73MGmACerS4v+uQZCGr5ZrJyYu01Q4wVXPPgSGk80WcmYtuejySyqv+4W8lGbJduTLVHBjxYjac0iVlqBlg4gzJnTu/y1ITPQAAHkdzWSZXKGElnikP3+g9VC0Pjan0uQfcDtgshKvrScyGUzjSwJZbi/4+Oxw2i+rOvRVZptEg01IsjYVouickGc6RUR/mwummTcNijOe4i859Wxnrd+GGXX48e36r7r4YlTa4a3HKKLl7XxAW2qq7R1LNc2U4rXTu623MlVHCHTOX17RJM2oHmDhDXgeyhVJ52lRtcVdjKV2OZVBiKB8GKiMBtFDW3FVOBFsshCGvEz+Tv0e0du5EhFG/E6vNNHeDOnegttf9letSA9PNk6nVHFa5uGMxKjp307jv8DBevh5BvMqVUk6D1Nm59/fZcdN4P35+eWtxV9u5+1tYtac2nbBVDul0zGgd7ChPqcpdaqzJog6OR8WB6rzs375xdz8cVgtWdGru4WQODpsFHg0d8ojficvyTl8tNsjyn/e5sNLkzUjv/lQlfLqyVvTvy9cjcNktOLpb25vTTobPIzQ7VC2v1xOd+/Zz/+ERFEoMz13aXITnwtIXRct0ajX37B/Cq7PRTYUlkmye5c6RlmTrk2VCG9r0X71MDUmOGa2HqlyLbBYaxqnOl4mrlWWcUkFrdPtcXsgy6Mawz4m1Fjr3oMehKTSL6+Zep03X99pog0XbHC6ZtVLcXXYrhrzOmoNML89GcGxioOn5RzcxMdgHt8PatLgvxjIIqHSEtYve+apUcfveAfhcti26+1wkBZuFWjr9v/dAEIUS2xSuFVERGsZpZWFHZd1bezV3u1VyzFzSuFeykrehsXOXdW21sozTZoXDZmkYHrYQSYNIkulG/M6WOnetb6bD8tKOw2M+XUmKIz5XUxmpXNxbLDATNbzumXwRby7GekpvByRJ7dCoD+ebZMxIOe7mde1ADxd3m9WCdx4cxo8urm6yRM6FU9g90Fd3+bIajk8G4LBayvnumXwRqVxRw4Gq/oUdYZUbgYxAcszo69zV5rCU82U2tHXugBxB0KRzH/W54LBZMKqiWNYjpKu4S/8uPZIMIMk6iWwBqQYTuCkDZBlAHmSqkmVeX4ghX2Q9MZlazRF5K1OjdFmzPe5ADxd3AHjX4WGsxLObEg7nImldHnclfQ4rbts7UD5UreTKqJdlAH0RBDxXxmFr/5f24Kh2x4yWASZAGvqyWghriSzyRSnbvdGCcSXNVu0tRFNlSWTE79TtltHTuXNZRuthauXPy173Bm9IGaM694E+LEYzm3J6+PDSbXu7fzK1msNjPkRS+S3btJQsxtKq707bRU8X9/sOVVIiOa143JXce2AIby7FEUnmKrkyGtwygP7i3m6nDEePY0bLABNQiSBY38iW7aH9feqWT3icNmxk67/xLETTZavfqN+FuJz3ohU9xZ1vLLp5XF+S4qiKKVUj3DKA1LnniqVNw2QvX49gesjTdsttJ9IshmAjW0AiUxCdu5mM+F24adyPH8u6eypXQCiZ0+2UUXLvgSAYA164EkJE1sHVWyH1x/6Gk9lt+4HjjplmtjAlWjzuHD7IVM6VUXsH5LRho86kb7HEsBTNlDt3LpM06sZqkS0UsZEtaH5DfcfBIXz7k/fg1j36Ol81U6qpXBEOq0XV4FwjuB1yXtbdGWN4dTbSUxZIJdwx8/S55S1uO6DilBGdu8ncd2gEL89GEEvny+6JVpwynGMTA/A4rHju8joisiyjVXPXY4cMbbR/OpUzGfTAbiVNuruW6VQOH2RSGxrG8TitSNbp3FfiGRRKrLyQghdLrdJMJVdG2xsqEeG2FoqjminVTL4Il879qUqqc91nwymsb+R67jCVE/A4cM/+IL764iyO/6d/xsf/5hS+9cp8udAvyudKZi3p4HTuuvFt4v4jw/jiszP42aX18g+CEZ273WrBiekAfj4TwmH5nb5ZIiSnlYUdoWROdzeoFa2OGT7ApEWWAaRBppmVhObi7nXZcS1UO4u8+o1cbwSB1tAwo+BTqo3uNFI5/ftTlZQHmeSOtJfCwurxtx+/C2fmo3jq7BKeen0JPzy/CofVgnccHCo3Z2a7ZXq+uN+6ZxD9fXY8e2EVN8nDGEZo7oCkuz974a1yBLBaWcbfp09zL5WkXJl2DzApOTjqw+vzMVXP5c+rtamqEVJ4WE57cXfWn/Tlvu3xquKuv3Pf3uJORBjxNT4ETrewYk+Jz2WH32Urd+4vX4/A57ThoIYky27DYiHcvncQt+8dxB984IZNhX4xloHdSqodYe2i54u71UJ456Fh/PjiGvwuO1x2C4YMKo737B8CAPzTG8vwOtU7WNQmGlYTz+RRKDHNEkErHBrx4anXl6RFzE0KyTPnV2G3Et5+cEjT3zHsdSJXLJW7bTUTqgDgdVrrWiHn5WE13pUOuh2wW2nHdO6AJCU1mlJtZTl2NeOD7k2d+617B2BpwS7cTdQq9LlCyfThrp7X3AHJNbOWyOIHby1jYtCta6ikFkfGfAh4HAgnc6ptkIDkwXc7rDUPaxpRGWDazs7dq9ox88Pzq7h7X7D85qUWfth5Wdb21Vsh7UjniyjUiKtdiKYx5HWWLZkWC2HYq90OWQkNM6O4N55STecLhnTugPQmuBBJI5HJ4+JKoqclmUbwQn/3vqDZlyKKOyD53QEpekBvYFgtLBbC2+QvstbOTgoP01jcN7YnV0aJWsfM9VASM6sbePeR5kudq+GDTJfXNuC0WVR75HkEQbKGD19pg+SM+F2a3TLhZA5WC6mWioyk2ZSqkZ07n1I9MxdFifW23r5TEMUdUvHgm9uNOExVcs8Bqbir1ds5Ur6MNllGa664EXDHTLOMmWfkBE49xb3cua8lNRVRX4NM9/lIeosrqpmGXYtQModBt90UiaLZlGpKhVSmlvGBPmxkC3j2/BqIsG2H9gL9iOIuc99hqegYdZjKuVfW3dU6ZTh6Yn+5LDO0jYMldqsF+4a8TR0zz5xfxf5hDyaDHs1/B//3bGQLmoo7T4asnlItlRgWomlMVFnVRv0uzZr7dixGqUezKdVM3kjNXXqtnjy7iMOjvvIshqBzEcVd5hePjgIADunM+qjHZNCNE9MB3Kax09GTDMllGbUBZUZxcNTb0Ou+kS3ghSshvOeGUV2ff6DPXs760VLcubZf3bmvb2SRK5Rqdu7RVF7TlKqe6VSj4FOq9d6QUrliS4s6lPCD59VEtqc2L+1kRHGXuWm8Hz/57P14p0YnRzOICN/4H9+Gj907renP6encw9uYK6Pk4IgPc5H6GTM/u7SGfJHpkmQAvtxCKqBGyDJ80rJac+fWNS26eyiZNbG4Nx68SueLhkXOKl+rXgwL24mI4q5gb9A4p0yr6FnYEUrmtlWS4RySHTMzdbr3H761Cr/L1tIhHP936ZFlqu2Q3FLJp1M5w0064VqY2bk38+Zn8sZp7lLYm1QuxGHqzkAU9w5FnyxjThd5cLT+6rFSieHZC6t41+GRlny//FBVrccdUMgyVW+SfBhni1vGV1lcrYZiiSGazm/rXIGSRlOq+WIJ+SKD26DOnYgwPtCHoMeByaCx51KC9tDzQ0ydinJhh1qZJWxQ6JlWpoLuuhkzZxdiWN/I4T06JRkO79x1FfctnXsKA277Fr+9mjAuJZFUDoyZ43EHGk+pGrFir5oP3LwLJcY65u5W0BhVVYOIHiCiC0Q0Q0SP1vj9zxDRm0R0loh+SESTxl9qb6FnYYcky2x/obE1cMw889YKLAS8S45X1gvv3HW5ZaqK+0J0qw0SkCKZbRZSbYesLB4xL/a2nsPHiBV71fzuLx7GZ993xLDPJ2gvTYs7EVkBPAbg/QCOAvgoER2tetqrAI4zxo4B+CaAPzb6QnsNrQs7SiVmqv57cNSLizWWZf/w/CrumBzEYIvXpUdzt1stcNosW4t7JF12fyixWAjDPqfqzp3LUAdGjHVYaWG0zpIRo1bsCXYuajr3EwBmGGNXGGM5AI8DeFj5BMbYs4wxHr/3AoAJYy+z9+Dyg9riHs/kUdzmXBklh0Z9mAunNw3ULMcyOLcYx7uP6LNAKtHjlgGkOyBlcWeMYT6S3nKYytEyyHRpdQN2K5mqQdebUjVqUYdg56KmuI8DmFN8PC8/Vo+PA/jHVi5KoF2W4QukzZBlgEoMweXVZPkxPpX6nhta09ulz++D1UKY0lhIq1ftRVJ5pPPFupn9WiIILq0ksG/Ia2pAVL0p1VQbZBnBzkLNd2Wt05Oam2GJ6NcBHAfwJ3V+/xNEdJqITq+tram/yh5E68IOM9MJgdqOmWfOr2BisM+QaNgbdvnx2h/+YvnvUYunakn2fGRz1G81Wjv3A6Pmxt7Wm1LNiM6951FT3OcB7FF8PAFgsfpJRPReAP8WwEOMsZqtD2PsS4yx44yx48PDrR2wdTs8+VBtMqQZuTJKJgNuOKyWsu6eyRfxs5l1vOfIiGHuCq1pkvzPJBTFfaHJtq1RvwuRVB65wtYkSSXpXBGz4RQOmai3A/WnVHnnbsSyDsHORE1xPwXgIBFNE5EDwEcAnFQ+gYhuA/BXkAr7ao3PIdCI1iXZFVnGHM3dZrVg37AHl+QAsecvh5DJl/BunZEDRlEty5Q3MDXQ3AFgbaOxNHN5bQOMSQfJZsI79+q7jYoVUoyy9CpNv/KMsQKARwA8DeAtAN9gjJ0joi8Q0UPy0/4EgBfA3xPRGSI6WefTCVRSWdihtnM3J1dGycFRHy7JnfsPz6/A7bDirumAadcDAF6XDUmFHr0QTcPntJW3XVUz4le3kYn/Ow+ZXNzrde6ZsuYuOvdeRdVXnjH2FICnqh77vOLX7zX4unoevrBDbeceTubgNyFXRsmhES+++9oiUrkCnnlrFW8/MGRYtolePDU69/HBvrpSUbOkRc6lFe6U0Z5yaSR8SrV6qpYfsArNvXcR92wdjJaFHesbWQRNkmQ4XKJ48jVpj6QRLplW8Tk3WyHnI6maHnfOSLkTbty5X1zZwPSQx/RVavWmVNN56cxAFPfeRRT3DkbLwg4zB5g43MnyVz+5DAC4/7D5xd0rxzjk5VV79aZTOUGPE1YLNe3cZ1YTOGjyYSqn1pRqWu7cediXoPcQX/kORkvsb2gjZ1rGCYc7Zi6vJXFsoh8jJm9/BzYnQ8bSeSQyhbo2SEBamD7kdTTU3DP5Iq6HU6YfpnJqd+7Sog6RA9O7iOLewWhJhgwlc9u6O7UW3DED6Fun1w68CtdRxQbZeBCq2UamslOmkzv3vHGLOgQ7E1HcOxi1nXupxBBJmQWKkpgAAAs7SURBVC/LANIkKQC8x4DIASNQJkOWB5gaaO5A80EmbvfsmM7d70Qis3lKNZUzblGHYGciinsHo3ZhRywt5coETcqVUfK+G8dw3+Fh3Ljbb/alAKgU92S2gIVo4wEmTrMIgkurCdgshCmTnTKcWg4fIxd1CHYmwgTbwfhVyjJ8MbbZsgwAfPDYLnzw2C6zL6MM19wT2QLmI2m47JamdzgjPidCyRzyxVJNN8zFlQ1MDXlMtZ0qUXrdp4akNxwj96cKdiad8d0pqInPVVnY0Qizc2U6GT7pm8wWylG/zQ4ZeSdcr3ufWd0wfXhJSa0p1bSQZXoeUdw7mEqme+PuPSSPyneCLNNpKFftSTbI5qmS9aY+AdkpE0qamuFeTa3rzYgD1Z5HFPcORm0yZCfJMp2Gp+pAtZENklMvrwUArqwlUWLmxw4oqTWlmsoVxQBTjyOKewejtnPvhFyZToV37quJLCKpfNPDVKBx584zZTrFBglUplSV18t97oLeRRT3DkZtMmRoI2t6rkynYrUQ+uxWXFiWinIzGyQABL1OWAhb8loAyQZptRCmhzrDKcMZ9bu2aO7CLdPbiGrQwajdxiQNMAm9vR5el61c3NV07tKUqrNmBMHFlQSmgu6OeyOt9uaLzl3QWd+hgk1UFnY069w7Y4CpU/E5bViWC5+aA1VAGgxaqREeJjllOkeS4SinVBljYkJVIIp7JzPglor7fDjV8HnhpPm5Mp0MP1R1WC0YVnmHM1pj8XQmX8S1UNKQtYFGw6dU07kisoUSGANcorj3NKK4dzA+lx13Tg3in84tN3xeJ+TKdDL8UHX3gAsWi7ogrRG/c0vs79V1ySmjdY/rdlCeUk1kkM6J/akCUdw7ngeP7cbFlY1Ni6eV8FwZ4XGvD+/c1dggOcM+F0LJHArFygAZ/xp0SqaMktHyBqksUnm+P1UU915GFPcO5/03jYEIePLsUs3f57kyQnOvDz+Yrrc3tRajficYq+ymBSS9vROdMkDtzl1MqPY2orh3OCN+F+6aDuDJs4tgjG35fTHA1ByPUypyWjr3WoNMF1cSmAy64bR1XtFUdu68uLvF/tSeRhT3HcAHj+3GlbUkzi9vlWZE9EBzvE7pYFqNx51Ta5Dp0uoGDnXQ8JIS5ZRqOi80d4Eo7juC9980BgsB36shzYjQsOaUZZkWOvdsoYjroc7ZvlSNckq1XNwd4se7lxFf/R3AkNeJe/YP1ZRmhCzTnP4+qXPfG1SvuQ95HSCqdO5X15MollhHOmU4fEqV70/tswtZppcRxX2H8MFju3AtlMK5xfimx0MbIlemGR+6bRx//Zt3Yle/+s7dZrUg6HGWIwgu8u1LHehx52zt3IUs08uI4r5DeODGMVgttMU1E06KXJlmeJ023H9Y+05XZRjXzEoCFkJ5R2wnwjv3VE5YIQWiuO8YBj0O3HtgCN97fbM0sy5yZdrGqL+S13JxZQNTQU9HOmU4wz5pSjUiS3XCCtnbiOK+g3jw2C7MhdM4Ox8rPxbeENED7WLEV8lrubSa6NjDVM6oXzoEvh6S4iqEW6a3EcV9B/G+o2OwWwnfe70izYSTIjSsXYz6nQhtSL7xa6FUR2W414LbN6+HUrBZSEh1PY746u8g+t12vOPgML53dqkszYSSWeGUaRPDfhdKDDh1LSw7ZTq7c+f2zWuhpOjaBaK47zQePLYLC9E0Xp2LyrkyeTHA1CZGfdLr+tzMOoDO2r5UC+XglXDKCFQVdyJ6gIguENEMET1a4/ffSUSvEFGBiH7F+MsUcN57dBQOqwVPvrYkcmXazIisYf9sZr3jnTJAZUoVEDZIgYriTkRWAI8BeD+AowA+SkRHq542C+BjAL5m9AUKNuN32fGuw8N46vUlrPPoASHLtAXeCb+5FMdk0NPx7hM+pQqIw1SBus79BIAZxtgVxlgOwOMAHlY+gTF2jTF2FkCp1icQGMuDx3ZhOZ7B999cASByZdrFkNcJIoCxzh5eUsIdM6JzF6gp7uMA5hQfz8uPaYaIPkFEp4no9Nramp5PIQDwnhtG4bRZ8NUXrgMQuTLtwm61ICBP/nb6YSpHdO4CjpriXmt1zdbsWRUwxr7EGDvOGDs+PDys51MIUJm4XIxJAzZDQpZpG1x378S9qbXgnbuYThWoKe7zAPYoPp4AsNieyxGo5cFbdpV/PSg697bBO+EDO0SWGZavt9PPBwTtR01xPwXgIBFNE5EDwEcAnGzvZQma8e4jI+izW+F32WC3Ckdruxj1O2EhYP/wzijuZc1dFPeep2kmKGOsQESPAHgagBXAlxlj54joCwBOM8ZOEtGdAL4NYBDALxHRf2SM3djWK+9x3A4bPnhsF2ZWN8y+lK7mXx7fg+kh747phLnDR8gyAlWBz4yxpwA8VfXY5xW/PgVJrhFsI//rh29GsaTr+EOgkuNTARyfCph9GarhU6ouUdx7HpHmv4MR2SGCanjnLmQZgSjuAkEX0d9nx2ffdxjvu3HM7EsRmIwo7gJBF0FE+NT9B8y+DEEHIO7rBQKBoAsRxV0gEAi6EFHcBQKBoAsRxV0gEAi6EFHcBQKBoAsRxV0gEAi6EFHcBQKBoAsRxV0gEAi6EGLMnGwSIloDcF3nHx8CsG7g5XQz4rVSh3id1CFeJ3W083WaZIw1XYhhWnFvBSI6zRg7bvZ17ATEa6UO8TqpQ7xO6uiE10nIMgKBQNCFiOIuEAgEXchOLe5fMvsCdhDitVKHeJ3UIV4ndZj+Ou1IzV0gEAgEjdmpnbtAIBAIGrDjijsRPUBEF4hohogeNft6OgUi+jIRrRLRG4rHAkT0AyK6JP9/0Mxr7ASIaA8RPUtEbxHROSL6tPy4eK0UEJGLiF4iotfk1+k/yo9PE9GL8uv0d0TkMPtaOwEishLRq0T0pPyx6a/TjiruRGQF8BiA9wM4CuCjRHTU3KvqGP4GwANVjz0K4IeMsYMAfih/3OsUAPwuY+wGAHcD+JT8PSReq81kAbybMXYLgFsBPEBEdwP4zwD+TH6dIgA+buI1dhKfBvCW4mPTX6cdVdwBnAAwwxi7whjLAXgcwMMmX1NHwBj7CYBw1cMPA/iK/OuvAPjQtl5UB8IYW2KMvSL/OgHpB3Ic4rXaBJPYkD+0y/8xAO8G8E358Z5/nQCAiCYAfBDAf5U/JnTA67TTivs4gDnFx/PyY4LajDLGlgCpqAEYMfl6OgoimgJwG4AXIV6rLchSwxkAqwB+AOAygChjrCA/Rfz8Sfw5gN8DUJI/DqIDXqedVtypxmPC7iPQDBF5AfwDgP+JMRY3+3o6EcZYkTF2K4AJSHfNN9R62vZeVWdBRA8CWGWMvax8uMZTt/112mkLsucB7FF8PAFg0aRr2QmsENEuxtgSEe2C1IH1PERkh1TYv8oY+5b8sHit6sAYixLRjyCdUQwQkU3uSsXPH3AvgIeI6AMAXAD8kDp501+nnda5nwJwUD6JdgD4CICTJl9TJ3MSwG/Iv/4NAN8x8Vo6AlkP/X8BvMUY+1PFb4nXSgERDRPRgPzrPgDvhXQ+8SyAX5Gf1vOvE2Psc4yxCcbYFKR69Axj7L9DB7xOO26ISX6H/HMAVgBfZoz9kcmX1BEQ0dcB3AcpjW4FwB8CeALANwDsBTAL4FcZY9WHrj0FEb0dwE8BvI6KRvoHkHR38VrJENExSAeBVkhN4DcYY18gon2QjAwBAK8C+HXGWNa8K+0ciOg+AP8zY+zBTniddlxxFwgEAkFzdposIxAIBAIViOIuEAgEXYgo7gKBQNCFiOIuEAgEXYgo7gKBQNCFiOIuEAgEXYgo7gKBQNCFiOIuEAgEXcj/D6jH2ZPA3LvTAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
@@ -1005,7 +1000,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Small changes to ku.ipynb to give users a command -- using curl -- to download a local copy of the Hydrotrend notebook.  

Update the calls to the model to refer to pymt.models() instead of pymt.plugins()