### PR TITLE
Add pymt to pymt_docs environment.yml

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -11,6 +11,7 @@ dependencies:
 - sphinx_rtd_theme
 - tornado
 - entrypoints
+- pymt
 - pip:
     - nbsphinx>=0.2.12
     - sphinxcontrib_github_alt


### PR DESCRIPTION

As it is, the environment.yml file in the pymt/docs/ folder does not contain package "pymt" as a dependency.  However, that is required in order to "make html".

This pull request simply adds "pymt" to the list of packages in the docs/environment.yml file.