### PR TITLE
Add help instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ _build
 # Auto-generated API docs
 docs/api/pymt.*rst
 docs/api/modules.rst
+
+# Jupyter Notebook
+.ipynb_checkpoints

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -25,7 +25,6 @@ Single Models
    demos/frost_number
    demos/ku
    demos/cem
-   demos/child
    demos/hydrotrend
    demos/sedflux3d
    demos/subside
@@ -37,4 +36,3 @@ Coupled Models
    :titlesonly:
 
    demos/cem_and_waves
-   demos/sedflux3d_and_child

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -19,20 +19,15 @@ have to first install Jupyter notebook:
 Single Models
 -------------
 
-.. toctree::
-   :titlesonly:
+* :doc:`Frost Number Model <demos/frost_number>` (macOS, Linux, Windows)
+* :doc:`Kudryavtsev Model <demos/ku>` (macOS, Linux, Windows)
+* :doc:`Coastline Evolution Model <demos/cem>` (macOS, Linux)
+* :doc:`Hydrotrend<demos/hydrotrend>` (macOS, Linux)
+* :doc:`Sedflux3D <demos/sedflux3d>` (macOS, Linux)
+* :doc:`Flexural Subsidence <demos/subside>` (macOS, Linux)
 
-   demos/frost_number
-   demos/ku
-   demos/cem
-   demos/hydrotrend
-   demos/sedflux3d
-   demos/subside
 
 Coupled Models
 --------------
 
-.. toctree::
-   :titlesonly:
-
-   demos/cem_and_waves
+* :doc:`Coastline Evolution Model + Waves <demos/cem_and_waves>` (macOS, Linux)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -77,6 +77,21 @@ Miscellaneous Pages
    history
    license
 
+
+Help
+----
+
+If you encounter any problems when using *pymt*,
+or if you find any bugs,
+please contact us at csdmssupport@colorado.edu.
+Or,
+if you're comfortable using GitHub,
+feel free to open an `issue`_
+in the *pymt* GitHub repository.
+
+.. _issue: https://github.com/csdms/pymt/issues
+
+
 Indices and tables
 ==================
 * :ref:`genindex`


### PR DESCRIPTION
Added a Help section to the bottom of the main page. It lists the CSDMS Support email, and points experienced users to log issues on the *pymt* GitHub page.

Also listed the operating systems that each example should work on.