### PR TITLE
Fix multiple authors error

### DIFF
--- a/pymt/events/port.py
+++ b/pymt/events/port.py
@@ -73,7 +73,7 @@ class PortEvent(GridMixIn):
             self._status_fp.flush()
             sys.stdout.flush()
             sys.stderr.flush()
-            print(yaml.dump(status))
+            print(yaml.dump(status, default_flow_style=True))
 
             self._port.run(time)
 

--- a/pymt/framework/bmi_setup.py
+++ b/pymt/framework/bmi_setup.py
@@ -79,7 +79,10 @@ class SetupMixIn(object):
 
     @property
     def author(self):
-        return self._meta.info["author"]
+        author = self._meta.info.get("author", self._meta.info.get("authors", ""))
+        if isinstance(author, str):
+            author = (author,)
+        return tuple(author)
 
     @property
     def email(self):
@@ -87,7 +90,7 @@ class SetupMixIn(object):
 
     @property
     def contact(self):
-        contact = self.author
+        contact = self.author[0]
         email = self.email
         if email != "-":
             contact = "{name} <{email}>".format(name=contact, email=email)

--- a/pymt/framework/bmi_setup.py
+++ b/pymt/framework/bmi_setup.py
@@ -12,6 +12,14 @@ from scripting.contexts import cd
 from .bmi_metadata import PluginMetadata
 
 
+def _parse_author_info(info):
+    """Get list of authors as a tuple."""
+    author = info.get("author", info.get("authors", ""))
+    if isinstance(author, str):
+        author = (author,)
+    return tuple(author)
+
+
 class SetupMixIn(object):
     def __init__(self):
         name = self.__class__.__name__.split(".")[-1]
@@ -79,10 +87,7 @@ class SetupMixIn(object):
 
     @property
     def author(self):
-        author = self._meta.info.get("author", self._meta.info.get("authors", ""))
-        if isinstance(author, str):
-            author = (author,)
-        return tuple(author)
+        return _parse_author_info(self._meta.info)
 
     @property
     def email(self):

--- a/tests/framework/test_setup.py
+++ b/tests/framework/test_setup.py
@@ -21,4 +21,7 @@ def test_author_as_list(key, iter):
 @pytest.mark.parametrize("key", ("author", "authors"))
 @pytest.mark.parametrize("iter", (tuple, list))
 def test_author_multiple_authors(key, iter):
-    assert _parse_author_info({key: iter(("John Cleese", "Eric Idle"))}) == ("John Cleese", "Eric Idle")
+    assert _parse_author_info({key: iter(("John Cleese", "Eric Idle"))}) == (
+        "John Cleese",
+        "Eric Idle",
+    )

--- a/tests/framework/test_setup.py
+++ b/tests/framework/test_setup.py
@@ -1,0 +1,24 @@
+import pytest
+
+from pymt.framework.bmi_setup import _parse_author_info
+
+
+@pytest.mark.parametrize("key", ("author", "authors"))
+def test_author(key):
+    assert _parse_author_info({key: "John Cleese"}) == ("John Cleese",)
+
+
+def test_author_empty_list():
+    assert _parse_author_info({}) == ("",)
+
+
+@pytest.mark.parametrize("key", ("author", "authors"))
+@pytest.mark.parametrize("iter", (tuple, list))
+def test_author_as_list(key, iter):
+    assert _parse_author_info({key: iter(("John Cleese",))}) == ("John Cleese",)
+
+
+@pytest.mark.parametrize("key", ("author", "authors"))
+@pytest.mark.parametrize("iter", (tuple, list))
+def test_author_multiple_authors(key, iter):
+    assert _parse_author_info({key: iter(("John Cleese", "Eric Idle"))}) == ("John Cleese", "Eric Idle")


### PR DESCRIPTION
This pull request fixes an error caused when a model's info metadata contains *authors* key (rather than *author* - singular). For now, anyway, I've changed it so that both are valid keys (look for *author* and then *authors*). The author list is now always a tuple.