### PR TITLE
Fix METADATA attribute

### DIFF
--- a/pymt/framework/bmi_metadata.py
+++ b/pymt/framework/bmi_metadata.py
@@ -94,7 +94,7 @@ def find_model_metadata(plugin):
         else:
             path_to_mmd = model_metadata_dir
 
-    return path_to_mmd
+    return os.path.abspath(path_to_mmd)
 
 
 class PluginMetadata(ModelMetadata):

--- a/pymt/framework/bmi_metadata.py
+++ b/pymt/framework/bmi_metadata.py
@@ -75,7 +75,7 @@ def find_model_metadata(plugin):
         Path to the folder that contains the plugin's metadata.
     """
     try:
-        model_metadata_dir = plugin.METADATA
+        model_metadata_dir = plugin.METADATA or "."
     except AttributeError:
         if isinstance(plugin, six.string_types):
             plugin_name = plugin

--- a/pymt/framework/bmi_metadata.py
+++ b/pymt/framework/bmi_metadata.py
@@ -87,9 +87,12 @@ def find_model_metadata(plugin):
 
         path_to_mmd = bmi_data_dir(plugin_name)
     else:
-        path_to_mmd = pkg_resources.resource_filename(
-            plugin.__module__, model_metadata_dir
-        )
+        if not os.path.isabs(model_metadata_dir):
+            path_to_mmd = pkg_resources.resource_filename(
+                plugin.__module__, model_metadata_dir
+            )
+        else:
+            path_to_mmd = model_metadata_dir
 
     return path_to_mmd
 

--- a/pymt/printers/nc/ugrid.py
+++ b/pymt/printers/nc/ugrid.py
@@ -153,7 +153,7 @@ class NetcdfField(object):
                 else:
                     variable[n_times] = array[0]
             else:
-                variable[:] = array.flat
+                variable[:] = array.reshape(variable.shape)
 
     def data_variable(self, name):
         return self.root.variables[name]

--- a/tests/framework/test_setup.py
+++ b/tests/framework/test_setup.py
@@ -29,7 +29,7 @@ def test_author_multiple_authors(key, iter):
     )
 
 
-@pytest.mark.parametrize("path_to_meta", ("", "meta", "/usr/local/share"))
+@pytest.mark.parametrize("path_to_meta", ("", ".", "meta", "/usr/local/share"))
 def test_find_metadata(path_to_meta):
     class _MyBmi:
         METADATA = path_to_meta

--- a/tests/framework/test_setup.py
+++ b/tests/framework/test_setup.py
@@ -1,6 +1,8 @@
+import os
 import pytest
 
 from pymt.framework.bmi_setup import _parse_author_info
+from pymt.framework.bmi_metadata import find_model_metadata
 
 
 @pytest.mark.parametrize("key", ("author", "authors"))
@@ -24,4 +26,15 @@ def test_author_multiple_authors(key, iter):
     assert _parse_author_info({key: iter(("John Cleese", "Eric Idle"))}) == (
         "John Cleese",
         "Eric Idle",
+    )
+
+
+@pytest.mark.parametrize("path_to_meta", ("", "meta", "/usr/local/share"))
+def test_find_metadata(path_to_meta):
+    class _MyBmi:
+        METADATA = path_to_meta
+
+    path_to_mmd = find_model_metadata(_MyBmi)
+    assert path_to_mmd == os.path.abspath(
+        os.path.join(os.path.dirname(__file__), path_to_meta)
     )

--- a/tests/framework/test_setup.py
+++ b/tests/framework/test_setup.py
@@ -31,10 +31,11 @@ def test_author_multiple_authors(key, iter):
 
 @pytest.mark.parametrize("path_to_meta", ("", ".", "meta", "/usr/local/share"))
 def test_find_metadata(path_to_meta):
+    expected = os.path.abspath(os.path.join(os.path.dirname(__file__), path_to_meta))
+    if expected.endswith(os.path.sep):
+        expected = expected[:-1]
+
     class _MyBmi:
         METADATA = path_to_meta
 
-    path_to_mmd = find_model_metadata(_MyBmi)
-    assert path_to_mmd == os.path.abspath(
-        os.path.join(os.path.dirname(__file__), path_to_meta)
-    )
+    assert find_model_metadata(_MyBmi) == expected


### PR DESCRIPTION
Fix an issue where the `.METADATA` attribute of a *BMI* class wasn't working properly. If the path was provided as an absolute path, the path to the *pymt* module was prepended to it rather that just using the provided path.