### PR TITLE
Fix finding metadata from BMI class

### DIFF
--- a/pymt/framework/bmi_setup.py
+++ b/pymt/framework/bmi_setup.py
@@ -24,7 +24,7 @@ class SetupMixIn(object):
     def __init__(self):
         name = self.__class__.__name__.split(".")[-1]
 
-        self._meta = PluginMetadata(self)
+        self._meta = PluginMetadata(self._bmi)
 
         self._defaults = {}
         self._parameters = {}


### PR DESCRIPTION
This pull request fixes a error when loading BMI classes that use the `METADATA` attribute to indicate where their model metadata is located. The metadata was being searched for based on the name of the model. Instead the class of the model should be used so that the `METADATA` attribute can be queried.