### PR TITLE
Fix cfunits import error on Windows

### DIFF
--- a/pymt/__init__.py
+++ b/pymt/__init__.py
@@ -1,3 +1,6 @@
+import os
+import sys
+
 import numpy as np
 
 from ._version import get_versions
@@ -12,3 +15,13 @@ try:
 except TypeError:
     pass
 del np
+
+
+os.environ.setdefault(
+    "UDUNITS2_XML_PATH",
+    os.path.abspath(
+        os.path.join(sys.prefix, "lib/site-packages/cfunits/etc/udunits/udunits2.xml")
+    ),
+)
+
+del os, sys


### PR DESCRIPTION
This fixes an issue on Windows where the units database could not be found (`udunits2.xml`). This resulted as an assertion error when importing *cfunits* from within *pymt*,
```python
>>> import cfunits
Traceback (most recent call last):
...
    assert(0 == _ut_unmap_symbol_to_unit(_ut_system, _c_char_p(b'Sv'), _UT_ASCII))
```
The issue is that *udunits2* library can not correctly find `udunits2.xml` in the default location. On Windows anyway. To fix this, I set the `UDUNITS_XML_PATH` environment variable in `pymt/__init__.py` to point to the path of `udunits2.xml` within the *cfunits* package. I do this for all platforms, not just Windows but I think that should be fine.