### PR TITLE
Refactor pymt.framework.bmi_ugrid module and add tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,15 +23,13 @@ install:
   - cmd: conda update --yes --quiet conda
   - cmd: set PYTHONUNBUFFERED=1
   - cmd: conda config --set always_yes yes
-  - cmd: conda update conda
   - cmd: conda config --append channels conda-forge
   - cmd: conda env create -n test_env --file ci/requirements-$CONDA_ENV.yml
   - cmd: conda activate test_env
   - cmd: python --version
-  - cmd: python setup.py install
-
+  - cmd: pip install -e .
 
 build: false
 
 test_script:
-  - pytest
+  - pytest -vvv

--- a/pymt/framework/bmi_ugrid.py
+++ b/pymt/framework/bmi_ugrid.py
@@ -23,6 +23,7 @@ class _Base(xr.Dataset):
     def __init__(self, bmi, grid_id):
         self.bmi = bmi
         self.grid_id = grid_id
+        self.grid_type = bmi.grid_type(grid_id)
         self.ndim = bmi.grid_ndim(grid_id)
         self.metadata = OrderedDict()
         super(_Base, self).__init__()
@@ -96,7 +97,7 @@ class Scalar(_Base):
                 ("cf_role", "grid_topology"),
                 ("long_name", "scalar value"),
                 ("topology_dimension", self.ndim),
-                ("type", "scalar"),
+                ("type", self.grid_type),
             ]
         )
         self.set_mesh()
@@ -115,7 +116,7 @@ class Vector(_Base):
                 ("cf_role", "grid_topology"),
                 ("long_name", "vector value"),
                 ("topology_dimension", self.ndim),
-                ("type", "vector"),
+                ("type", self.grid_type),
             ]
         )
         self.set_mesh()
@@ -132,7 +133,7 @@ class Points(_Base):
                 ("long_name", "Topology data of 2D unstructured points"),
                 ("topology_dimension", self.ndim),
                 ("node_coordinates", "node_x node_y"),
-                ("type", "points"),
+                ("type", self.grid_type),
             ]
         )
         self.set_mesh()
@@ -150,7 +151,7 @@ class Unstructured(_Base):
                 ("long_name", "Topology data of 2D unstructured points"),
                 ("topology_dimension", self.ndim),
                 ("node_coordinates", "node_x node_y"),
-                ("type", "unstructured"),
+                ("type", self.grid_type),
             ]
         )
         self.set_mesh()
@@ -179,7 +180,7 @@ class StructuredQuadrilateral(_Base):
                 ("topology_dimension", self.ndim),
                 ("node_coordinates", " ".join(coordinate_names(self.ndim))),
                 ("node_dimensions", " ".join(index_names(self.ndim))),
-                ("type", "structured_quadrilateral"),
+                ("type", self.grid_type),
             ]
         )
         self.set_mesh()

--- a/pymt/framework/bmi_ugrid.py
+++ b/pymt/framework/bmi_ugrid.py
@@ -3,6 +3,9 @@ from collections import OrderedDict
 import numpy as np
 import xarray as xr
 
+from landlab.graph import StructuredQuadGraph
+
+
 COORDINATE_NAMES = ["z", "y", "x"]
 INDEX_NAMES = ["k", "j", "i"]
 
@@ -31,6 +34,21 @@ class _Base(xr.Dataset):
             }
         )
 
+    def set_shape(self, shape):
+        self.update(
+            {
+                "node_shape": xr.DataArray(data=shape, dims=("rank",))
+            }
+        )
+
+    def get_nodes(self):
+        nodes = []
+        for dim_name in COORDINATE_NAMES[: -(self.ndim + 1) : -1]:
+            data = getattr(self.bmi, "grid_" + dim_name)(self.grid_id)
+            nodes.insert(0, data)
+
+        return tuple(nodes)
+
     def set_nodes(self):
         coords = {}
         for dim_name in COORDINATE_NAMES[: -(self.ndim + 1) : -1]:
@@ -44,17 +62,21 @@ class _Base(xr.Dataset):
 
         self.update(coords)
 
-    def set_connectivity(self):
+    def set_connectivity(self, data=None):
+        if data is None:
+            data = self.bmi.grid_face_nodes(self.grid_id)
         face_node_connectivity = xr.DataArray(
-            data=self.bmi.grid_face_nodes(self.grid_id),
+            data=data,
             dims=("vertex",),
             attrs={"standard_name": "Face-node connectivity"},
         )
         self.update({"face_node_connectivity": face_node_connectivity})
 
-    def set_offset(self):
+    def set_offset(self, data=None):
+        if data is None:
+            data = self.bmi.grid_face_node_offset(self.grid_id)
         face_node_offset = xr.DataArray(
-            data=self.bmi.grid_face_node_offset(self.grid_id),
+            data=data,
             dims=("face",),
             attrs={"standard_name": "Offset to face-node connectivity"},
         )
@@ -137,6 +159,41 @@ class Unstructured(_Base):
         self.set_offset()
 
 
+class StructuredQuadrilateral(_Base):
+
+    def __init__(self, *args):
+        super(StructuredQuadrilateral, self).__init__(*args)
+
+        if self.ndim < 1 or self.ndim > 3:
+            raise ValueError("structured_quadrilateral grid must be rank 1, 2, or 3")
+
+        shape = self.bmi.grid_shape(self.grid_id)
+
+        self.metadata = OrderedDict(
+            [
+                ("cf_role", "grid_topology"),
+                (
+                    "long_name",
+                    "Topology data of {}D structured quadrilateral".format(self.ndim),
+                ),
+                ("topology_dimension", self.ndim),
+                ("node_coordinates", " ".join(coordinate_names(self.ndim))),
+                ("node_dimensions", " ".join(index_names(self.ndim))),
+                ("type", "structured_quadrilateral"),
+            ]
+        )
+        self.set_mesh()
+        self.set_shape(shape)
+        nodes = self.get_nodes()
+        self.set_nodes()
+
+        graph = StructuredQuadGraph(nodes, shape=tuple(shape))
+
+        self.set_connectivity(data=graph.nodes_at_patch.reshape((-1,)))
+        self.set_offset(data=np.arange(1, graph.number_of_patches + 1,
+                                       dtype=np.int32) * 4)
+
+
 def dataset_from_bmi_grid(bmi, grid_id):
     grid_type = bmi.grid_type(grid_id)
     if grid_type == "points":
@@ -144,7 +201,7 @@ def dataset_from_bmi_grid(bmi, grid_id):
     elif grid_type == "uniform_rectilinear":
         grid = dataset_from_bmi_uniform_rectilinear(bmi, grid_id)
     elif grid_type == "structured_quadrilateral":
-        grid = dataset_from_bmi_structured_quadrilateral(bmi, grid_id)
+        grid = StructuredQuadrilateral(bmi, grid_id)
     elif grid_type == "scalar":
         grid = Scalar(bmi, grid_id)
     elif grid_type.startswith("unstructured"):
@@ -231,72 +288,5 @@ def dataset_from_bmi_uniform_rectilinear(bmi, grid_id):
                 )
             }
         )
-
-    return dataset
-
-
-def dataset_from_bmi_structured_quadrilateral(bmi, grid_id):
-    from landlab.graph import StructuredQuadGraph
-
-    rank = bmi.grid_ndim(grid_id)
-    shape = bmi.grid_shape(grid_id)
-
-    if rank < 1 or rank > 3:
-        raise ValueError("structured_quadrilateral grids must be rank 1, 2, or 3")
-
-    attrs = OrderedDict(
-        [
-            ("cf_role", "grid_topology"),
-            (
-                "long_name",
-                "Topology data of {}D structured quadrilateral".format(rank),
-            ),
-            ("topology_dimension", rank),
-            ("node_coordinates", " ".join(coordinate_names(rank))),
-            ("node_dimensions", " ".join(index_names(rank))),
-            ("type", "structured_quad"),
-        ]
-    )
-
-    dataset = xr.Dataset(
-        {
-            "mesh": xr.DataArray(data=grid_id, attrs=attrs),
-            "node_shape": xr.DataArray(data=shape, dims=("rank",)),
-        }
-    )
-
-    nodes = []
-    coords = {}
-    for dim_name in COORDINATE_NAMES[: -(rank + 1) : -1]:
-        data = getattr(bmi, "grid_" + dim_name)(grid_id)
-        nodes.insert(0, data.copy())
-        coord = xr.DataArray(
-            data=data,
-            dims=("node",),
-            attrs={"standard_name": dim_name, "units": "m"}
-        )
-        coords["node_" + dim_name] = coord
-
-    graph = StructuredQuadGraph(nodes, shape=tuple(shape))
-
-    dataset.update(coords)
-    dataset.update(
-        {
-            "face_node_connectivity": xr.DataArray(
-                data=graph.nodes_at_patch.reshape((-1,)),
-                dims=("vertex",),
-                attrs={"standard_name": "Face-node connectivity"},
-            )
-        }
-    )
-    dataset.update(
-        {
-            "face_node_offset": xr.DataArray(
-                data=np.arange(1, graph.number_of_patches + 1, dtype=np.int32) * 4,
-                dims=("face",),
-                attrs={"standard_name": "Offset to face-node connectivity"},
-            )
-        }
-    )
 
     return dataset

--- a/pymt/framework/bmi_ugrid.py
+++ b/pymt/framework/bmi_ugrid.py
@@ -5,7 +5,6 @@ import xarray as xr
 
 from landlab.graph import StructuredQuadGraph, UniformRectilinearGraph
 
-
 COORDINATE_NAMES = ["z", "y", "x"]
 INDEX_NAMES = ["k", "j", "i"]
 
@@ -19,7 +18,6 @@ def coordinate_names(rank):
 
 
 class _Base(xr.Dataset):
-
     def __init__(self, bmi, grid_id):
         self.bmi = bmi
         self.grid_id = grid_id
@@ -29,32 +27,16 @@ class _Base(xr.Dataset):
         super(_Base, self).__init__()
 
     def set_mesh(self):
-        self.update(
-            {
-                "mesh": xr.DataArray(data=self.grid_id, attrs=self.metadata)
-            }
-        )
+        self.update({"mesh": xr.DataArray(data=self.grid_id, attrs=self.metadata)})
 
     def set_shape(self, shape):
-        self.update(
-            {
-                "node_shape": xr.DataArray(data=shape, dims=("rank",))
-            }
-        )
+        self.update({"node_shape": xr.DataArray(data=shape, dims=("rank",))})
 
     def set_spacing(self, spacing):
-        self.update(
-            {
-                "node_spacing": xr.DataArray(data=spacing, dims=("rank",))
-            }
-        )
+        self.update({"node_spacing": xr.DataArray(data=spacing, dims=("rank",))})
 
     def set_origin(self, origin):
-        self.update(
-            {
-                "node_origin": xr.DataArray(data=origin, dims=("rank",))
-            }
-        )
+        self.update({"node_origin": xr.DataArray(data=origin, dims=("rank",))})
 
     def get_nodes(self):
         nodes = []
@@ -71,7 +53,7 @@ class _Base(xr.Dataset):
             coord = xr.DataArray(
                 data=data,
                 dims=("node",),
-                attrs={"standard_name": dim_name, "units": "m"}
+                attrs={"standard_name": dim_name, "units": "m"},
             )
             coords["node_" + dim_name] = coord
 
@@ -99,7 +81,6 @@ class _Base(xr.Dataset):
 
 
 class Scalar(_Base):
-
     def __init__(self, *args):
         super(Scalar, self).__init__(*args)
 
@@ -118,7 +99,6 @@ class Scalar(_Base):
 
 
 class Vector(_Base):
-
     def __init__(self, *args):
         super(Vector, self).__init__(*args)
 
@@ -137,7 +117,6 @@ class Vector(_Base):
 
 
 class Points(_Base):
-
     def __init__(self, *args):
         super(Points, self).__init__(*args)
 
@@ -155,7 +134,6 @@ class Points(_Base):
 
 
 class Unstructured(_Base):
-
     def __init__(self, *args):
         super(Unstructured, self).__init__(*args)
 
@@ -175,7 +153,6 @@ class Unstructured(_Base):
 
 
 class StructuredQuadrilateral(_Base):
-
     def __init__(self, *args):
         super(StructuredQuadrilateral, self).__init__(*args)
 
@@ -205,12 +182,12 @@ class StructuredQuadrilateral(_Base):
         graph = StructuredQuadGraph(nodes, shape=tuple(shape))
 
         self.set_connectivity(data=graph.nodes_at_patch.reshape((-1,)))
-        self.set_offset(data=np.arange(1, graph.number_of_patches + 1,
-                                       dtype=np.int32) * 4)
+        self.set_offset(
+            data=np.arange(1, graph.number_of_patches + 1, dtype=np.int32) * 4
+        )
 
 
 class UniformRectilinear(_Base):
-
     def __init__(self, *args):
         super(UniformRectilinear, self).__init__(*args)
 
@@ -251,17 +228,18 @@ class UniformRectilinear(_Base):
         graph = UniformRectilinearGraph(shape, spacing=spacing, origin=origin)
 
         self.set_connectivity(data=graph.nodes_at_patch.reshape((-1,)))
-        self.set_offset(data=np.arange(1, graph.number_of_patches + 1,
-                                       dtype=np.int32) * 4)
+        self.set_offset(
+            data=np.arange(1, graph.number_of_patches + 1, dtype=np.int32) * 4
+        )
 
     def set_nodes(self, grid_coords=None):
         coords_at_node = np.meshgrid(*grid_coords, indexing="ij")
         coords = {}
-        for axis, dim_name in enumerate(COORDINATE_NAMES[-self.ndim:]):
+        for axis, dim_name in enumerate(COORDINATE_NAMES[-self.ndim :]):
             coord = xr.DataArray(
                 data=coords_at_node[axis].reshape(-1),
                 dims=("node",),
-                attrs={"standard_name": dim_name, "units": "m"}
+                attrs={"standard_name": dim_name, "units": "m"},
             )
             coords["node_" + dim_name] = coord
 

--- a/pymt/framework/bmi_ugrid.py
+++ b/pymt/framework/bmi_ugrid.py
@@ -64,7 +64,7 @@ class _Base(xr.Dataset):
 
         return tuple(nodes)
 
-    def set_nodes(self):
+    def set_nodes(self, grid_coords=None):
         coords = {}
         for dim_name in COORDINATE_NAMES[: -(self.ndim + 1) : -1]:
             data = getattr(self.bmi, "grid_" + dim_name)(self.grid_id)
@@ -246,7 +246,7 @@ class UniformRectilinear(_Base):
             grid_coords.append(
                 np.arange(shape[dim], dtype=float) * spacing[dim] + origin[dim]
             )
-        self.set_nodes(grid_coords)
+        self.set_nodes(grid_coords=grid_coords)
 
         graph = UniformRectilinearGraph(shape, spacing=spacing, origin=origin)
 
@@ -254,7 +254,7 @@ class UniformRectilinear(_Base):
         self.set_offset(data=np.arange(1, graph.number_of_patches + 1,
                                        dtype=np.int32) * 4)
 
-    def set_nodes(self, grid_coords):
+    def set_nodes(self, grid_coords=None):
         coords_at_node = np.meshgrid(*grid_coords, indexing="ij")
         coords = {}
         for axis, dim_name in enumerate(COORDINATE_NAMES[-self.ndim:]):

--- a/tests/framework/test_bmi_ugrid.py
+++ b/tests/framework/test_bmi_ugrid.py
@@ -2,7 +2,7 @@
 import xarray as xr
 import numpy as np
 
-from pymt.framework.bmi_ugrid import Scalar, Vector, Points
+from pymt.framework.bmi_ugrid import Scalar, Vector, Points, Unstructured
 from pymt.framework.bmi_bridge import _BmiCap
 
 
@@ -83,4 +83,48 @@ def test_points_grid():
     assert grid.ndim == 2
     assert grid.metadata["type"] == "points"
     assert grid.data_vars["mesh"].attrs["type"] == "points"
+    assert type(grid.data_vars["node_x"].data) == np.ndarray
+
+
+class TestUnstructured:
+
+    x = np.array([0, 1, 0, 1])
+    y = np.array([0, 0, 1, 1])
+    node_count = x.size
+
+    def get_grid_rank(self, grid_id):
+        return 2
+
+    def get_grid_node_count(self, grid_id):
+        return self.node_count
+
+    def get_grid_x(self, grid_id, out=None):
+        return self.x
+
+    def get_grid_y(self, grid_id, out=None):
+        return self.y
+
+    def get_grid_number_of_faces(self, grid_id):
+        return 1
+
+    def get_grid_nodes_per_face(self, grid_id, out=None):
+        return 4
+
+    def get_grid_face_nodes(self, grid_id, out=None):
+        return 4
+
+
+class UnstructuredBmi(_BmiCap):
+    _cls = TestUnstructured
+
+
+def test_unstructured_grid():
+    """Test creating an unstructured grid."""
+    bmi = UnstructuredBmi()
+    grid = Unstructured(bmi, grid_id)
+
+    assert isinstance(grid, xr.Dataset)
+    assert grid.ndim == 2
+    assert grid.metadata["type"] == "unstructured"
+    assert grid.data_vars["mesh"].attrs["type"] == "unstructured"
     assert type(grid.data_vars["node_x"].data) == np.ndarray

--- a/tests/framework/test_bmi_ugrid.py
+++ b/tests/framework/test_bmi_ugrid.py
@@ -1,7 +1,8 @@
 """Unit tests for the pymt.framwork.bmi_ugrid module."""
 import xarray as xr
+import numpy as np
 
-from pymt.framework.bmi_ugrid import Scalar, Vector
+from pymt.framework.bmi_ugrid import Scalar, Vector, Points
 from pymt.framework.bmi_bridge import _BmiCap
 
 
@@ -19,7 +20,7 @@ class ScalarBmi(_BmiCap):
 
 
 def test_scalar_grid():
-    """Testing creating a scalar grid."""
+    """Test creating a scalar grid."""
     bmi = ScalarBmi()
     grid = Scalar(bmi, grid_id)
 
@@ -40,7 +41,7 @@ class VectorBmi(_BmiCap):
 
 
 def test_vector_grid():
-    """Testing creating a vector grid."""
+    """Test creating a vector grid."""
     bmi = VectorBmi()
     grid = Vector(bmi, grid_id)
 
@@ -48,3 +49,38 @@ def test_vector_grid():
     assert grid.metadata["type"] == "vector"
     assert grid.data_vars["mesh"].attrs["type"] == "vector"
     assert isinstance(grid, xr.Dataset)
+
+
+class TestPoints:
+
+    node_count = 6
+    x = np.random.rand(node_count)
+    y = np.random.rand(node_count)
+
+    def get_grid_rank(self, grid_id):
+        return 2
+
+    def get_grid_node_count(self, grid_id):
+        return self.node_count
+
+    def get_grid_x(self, grid_id, out=None):
+        return self.x
+
+    def get_grid_y(self, grid_id, out=None):
+        return self.y
+
+
+class PointsBmi(_BmiCap):
+    _cls = TestPoints
+
+
+def test_points_grid():
+    """Test creating a grid from points."""
+    bmi = PointsBmi()
+    grid = Points(bmi, grid_id)
+
+    assert isinstance(grid, xr.Dataset)
+    assert grid.ndim == 2
+    assert grid.metadata["type"] == "points"
+    assert grid.data_vars["mesh"].attrs["type"] == "points"
+    assert type(grid.data_vars["node_x"].data) == np.ndarray

--- a/tests/framework/test_bmi_ugrid.py
+++ b/tests/framework/test_bmi_ugrid.py
@@ -11,6 +11,9 @@ grid_id = 0
 
 class BmiScalar:
 
+    def grid_type(self, grid_id):
+        return "scalar"
+
     def grid_ndim(self, grid_id):
         return 0
 
@@ -21,12 +24,15 @@ def test_scalar_grid():
     grid = Scalar(bmi, grid_id)
 
     assert grid.ndim == 0
-    assert grid.metadata["type"] == "scalar"
-    assert grid.data_vars["mesh"].attrs["type"] == "scalar"
+    assert grid.metadata["type"] == bmi.grid_type(grid_id)
+    assert grid.data_vars["mesh"].attrs["type"] == bmi.grid_type(grid_id)
     assert isinstance(grid, xr.Dataset)
 
 
 class BmiVector:
+
+    def grid_type(self, grid_id):
+        return "vector"
 
     def grid_ndim(self, grid_id):
         return 1
@@ -38,8 +44,8 @@ def test_vector_grid():
     grid = Vector(bmi, grid_id)
 
     assert grid.ndim == 1
-    assert grid.metadata["type"] == "vector"
-    assert grid.data_vars["mesh"].attrs["type"] == "vector"
+    assert grid.metadata["type"] == bmi.grid_type(grid_id)
+    assert grid.data_vars["mesh"].attrs["type"] == bmi.grid_type(grid_id)
     assert isinstance(grid, xr.Dataset)
 
 
@@ -47,6 +53,9 @@ class BmiPoints:
 
     x = np.array([0., 1., 0., 1.])
     y = np.array([0., 0., 1., 1.])
+
+    def grid_type(self, grid_id):
+        return "points"
 
     def grid_ndim(self, grid_id):
         return 2
@@ -65,12 +74,15 @@ def test_points_grid():
 
     assert isinstance(grid, xr.Dataset)
     assert grid.ndim == 2
-    assert grid.metadata["type"] == "points"
-    assert grid.data_vars["mesh"].attrs["type"] == "points"
+    assert grid.metadata["type"] == bmi.grid_type(grid_id)
+    assert grid.data_vars["mesh"].attrs["type"] == bmi.grid_type(grid_id)
     assert type(grid.data_vars["node_x"].data) == np.ndarray
 
 
 class BmiUnstructured(BmiPoints):
+
+    def grid_type(self, grid_id):
+        return "unstructured"
 
     def grid_nodes_per_face(self, grid_id, out=None):
         return 4
@@ -90,8 +102,8 @@ def test_unstructured_grid():
 
     assert isinstance(grid, xr.Dataset)
     assert grid.ndim == 2
-    assert grid.metadata["type"] == "unstructured"
-    assert grid.data_vars["mesh"].attrs["type"] == "unstructured"
+    assert grid.metadata["type"] == bmi.grid_type(grid_id)
+    assert grid.data_vars["mesh"].attrs["type"] == bmi.grid_type(grid_id)
     assert type(grid.data_vars["node_x"].data) == np.ndarray
 
 
@@ -99,6 +111,9 @@ class BmiStructuredQuadrilateral():
 
     x = np.array([[0., 3.], [1., 4.], [2., 5.]])
     y = np.array([[0., 1.], [2., 3.], [4., 5.]])
+
+    def grid_type(self, grid_id):
+        return "structured_quadrilateral"
 
     def grid_ndim(self, grid_id):
         return self.x.ndim
@@ -120,6 +135,6 @@ def test_structured_quadrilateral_grid():
 
     assert isinstance(grid, xr.Dataset)
     assert grid.ndim == 2
-    assert grid.metadata["type"] == "structured_quadrilateral"
-    assert grid.data_vars["mesh"].attrs["type"] == "structured_quadrilateral"
+    assert grid.metadata["type"] == bmi.grid_type(grid_id)
+    assert grid.data_vars["mesh"].attrs["type"] == bmi.grid_type(grid_id)
     assert type(grid.data_vars["node_x"].data) == np.ndarray

--- a/tests/framework/test_bmi_ugrid.py
+++ b/tests/framework/test_bmi_ugrid.py
@@ -3,7 +3,6 @@ import xarray as xr
 import numpy as np
 
 from pymt.framework.bmi_ugrid import Scalar, Vector, Points, Unstructured
-from pymt.framework.bmi_bridge import _BmiCap
 
 
 grid_id = 0
@@ -11,17 +10,12 @@ grid_id = 0
 
 class TestScalar:
 
-    def get_grid_rank(self, grid_id):
+    def grid_ndim(self, grid_id):
         return 0
-
-
-class ScalarBmi(_BmiCap):
-    _cls = TestScalar
-
 
 def test_scalar_grid():
     """Test creating a scalar grid."""
-    bmi = ScalarBmi()
+    bmi = TestScalar()
     grid = Scalar(bmi, grid_id)
 
     assert grid.ndim == 0
@@ -32,17 +26,13 @@ def test_scalar_grid():
 
 class TestVector:
 
-    def get_grid_rank(self, grid_id):
+    def grid_ndim(self, grid_id):
         return 1
-
-
-class VectorBmi(_BmiCap):
-    _cls = TestVector
 
 
 def test_vector_grid():
     """Test creating a vector grid."""
-    bmi = VectorBmi()
+    bmi = TestVector()
     grid = Vector(bmi, grid_id)
 
     assert grid.ndim == 1
@@ -55,28 +45,20 @@ class TestPoints:
 
     x = np.array([0., 1., 0., 1.])
     y = np.array([0., 0., 1., 1.])
-    node_count = x.size
 
-    def get_grid_rank(self, grid_id):
+    def grid_ndim(self, grid_id):
         return 2
 
-    def get_grid_node_count(self, grid_id):
-        return self.node_count
-
-    def get_grid_x(self, grid_id, out=None):
+    def grid_x(self, grid_id, out=None):
         return self.x.flatten()
 
-    def get_grid_y(self, grid_id, out=None):
+    def grid_y(self, grid_id, out=None):
         return self.y.flatten()
-
-
-class PointsBmi(_BmiCap):
-    _cls = TestPoints
 
 
 def test_points_grid():
     """Test creating a grid from points."""
-    bmi = PointsBmi()
+    bmi = TestPoints()
     grid = Points(bmi, grid_id)
 
     assert isinstance(grid, xr.Dataset)
@@ -88,23 +70,20 @@ def test_points_grid():
 
 class TestUnstructured(TestPoints):
 
-    def get_grid_number_of_faces(self, grid_id):
-        return 1
-
-    def get_grid_nodes_per_face(self, grid_id, out=None):
+    def grid_nodes_per_face(self, grid_id, out=None):
         return 4
 
-    def get_grid_face_nodes(self, grid_id, out=None):
+    def grid_face_nodes(self, grid_id, out=None):
         return np.array([0, 1, 3, 2])
 
-
-class UnstructuredBmi(_BmiCap):
-    _cls = TestUnstructured
+    def grid_face_node_offset(self, grid_id, out=None):
+        nodes_per_face = self.grid_nodes_per_face(grid_id)
+        return np.cumsum(nodes_per_face)
 
 
 def test_unstructured_grid():
     """Test creating an unstructured grid."""
-    bmi = UnstructuredBmi()
+    bmi = TestUnstructured()
     grid = Unstructured(bmi, grid_id)
 
     assert isinstance(grid, xr.Dataset)

--- a/tests/framework/test_bmi_ugrid.py
+++ b/tests/framework/test_bmi_ugrid.py
@@ -53,8 +53,8 @@ def test_vector_grid():
 
 class TestPoints:
 
-    x = np.array([0, 1, 0, 1])
-    y = np.array([0, 0, 1, 1])
+    x = np.array([0., 1., 0., 1.])
+    y = np.array([0., 0., 1., 1.])
     node_count = x.size
 
     def get_grid_rank(self, grid_id):

--- a/tests/framework/test_bmi_ugrid.py
+++ b/tests/framework/test_bmi_ugrid.py
@@ -1,0 +1,49 @@
+"""Unit tests for the pymt.framwork.bmi_ugrid module."""
+import numpy as np
+import xarray as xr
+
+from pymt.framework.bmi_ugrid import Scalar, Vector
+from pymt.framework.bmi_bridge import _BmiCap
+
+
+grid_id = 0
+
+
+class TestScalar:
+
+    def get_grid_rank(self, grid_id):
+        return 0
+
+
+class ScalarBmi(_BmiCap):
+    _cls = TestScalar
+
+
+def test_scalar_grid():
+    """Testing creating a scalar grid."""
+    bmi = ScalarBmi()
+    grid = Scalar(bmi, grid_id)
+
+    assert grid.ndim == 0
+    assert grid.metadata["type"] == "scalar"
+    assert isinstance(grid, xr.Dataset) == True
+
+
+class TestVector:
+
+    def get_grid_rank(self, grid_id):
+        return 1
+
+
+class VectorBmi(_BmiCap):
+    _cls = TestVector
+
+
+def test_vector_grid():
+    """Testing creating a vector grid."""
+    bmi = VectorBmi()
+    grid = Vector(bmi, grid_id)
+
+    assert grid.ndim == 1
+    assert grid.metadata["type"] == "vector"
+    assert isinstance(grid, xr.Dataset) == True

--- a/tests/framework/test_bmi_ugrid.py
+++ b/tests/framework/test_bmi_ugrid.py
@@ -25,6 +25,7 @@ def test_scalar_grid():
 
     assert grid.ndim == 0
     assert grid.metadata["type"] == "scalar"
+    assert grid.data_vars["mesh"].attrs["type"] == "scalar"
     assert isinstance(grid, xr.Dataset)
 
 
@@ -45,4 +46,5 @@ def test_vector_grid():
 
     assert grid.ndim == 1
     assert grid.metadata["type"] == "vector"
+    assert grid.data_vars["mesh"].attrs["type"] == "vector"
     assert isinstance(grid, xr.Dataset)

--- a/tests/framework/test_bmi_ugrid.py
+++ b/tests/framework/test_bmi_ugrid.py
@@ -64,10 +64,10 @@ class TestPoints:
         return self.node_count
 
     def get_grid_x(self, grid_id, out=None):
-        return self.x
+        return self.x.flatten()
 
     def get_grid_y(self, grid_id, out=None):
-        return self.y
+        return self.y.flatten()
 
 
 class PointsBmi(_BmiCap):

--- a/tests/framework/test_bmi_ugrid.py
+++ b/tests/framework/test_bmi_ugrid.py
@@ -1,5 +1,4 @@
 """Unit tests for the pymt.framwork.bmi_ugrid module."""
-import numpy as np
 import xarray as xr
 
 from pymt.framework.bmi_ugrid import Scalar, Vector
@@ -26,7 +25,7 @@ def test_scalar_grid():
 
     assert grid.ndim == 0
     assert grid.metadata["type"] == "scalar"
-    assert isinstance(grid, xr.Dataset) == True
+    assert isinstance(grid, xr.Dataset)
 
 
 class TestVector:
@@ -46,4 +45,4 @@ def test_vector_grid():
 
     assert grid.ndim == 1
     assert grid.metadata["type"] == "vector"
-    assert isinstance(grid, xr.Dataset) == True
+    assert isinstance(grid, xr.Dataset)

--- a/tests/framework/test_bmi_ugrid.py
+++ b/tests/framework/test_bmi_ugrid.py
@@ -53,9 +53,9 @@ def test_vector_grid():
 
 class TestPoints:
 
-    node_count = 6
-    x = np.random.rand(node_count)
-    y = np.random.rand(node_count)
+    x = np.array([0, 1, 0, 1])
+    y = np.array([0, 0, 1, 1])
+    node_count = x.size
 
     def get_grid_rank(self, grid_id):
         return 2
@@ -86,23 +86,7 @@ def test_points_grid():
     assert type(grid.data_vars["node_x"].data) == np.ndarray
 
 
-class TestUnstructured:
-
-    x = np.array([0, 1, 0, 1])
-    y = np.array([0, 0, 1, 1])
-    node_count = x.size
-
-    def get_grid_rank(self, grid_id):
-        return 2
-
-    def get_grid_node_count(self, grid_id):
-        return self.node_count
-
-    def get_grid_x(self, grid_id, out=None):
-        return self.x
-
-    def get_grid_y(self, grid_id, out=None):
-        return self.y
+class TestUnstructured(TestPoints):
 
     def get_grid_number_of_faces(self, grid_id):
         return 1
@@ -111,7 +95,7 @@ class TestUnstructured:
         return 4
 
     def get_grid_face_nodes(self, grid_id, out=None):
-        return 4
+        return np.array([0, 1, 3, 2])
 
 
 class UnstructuredBmi(_BmiCap):

--- a/tests/framework/test_bmi_ugrid.py
+++ b/tests/framework/test_bmi_ugrid.py
@@ -3,7 +3,9 @@ import xarray as xr
 import numpy as np
 
 from pymt.framework.bmi_ugrid import (Scalar, Vector, Points,
-                                      Unstructured, StructuredQuadrilateral)
+                                      Unstructured,
+                                      StructuredQuadrilateral,
+                                      UniformRectilinear)
 
 
 grid_id = 0
@@ -132,6 +134,40 @@ def test_structured_quadrilateral_grid():
     """Test creating a structured quadrilateral grid."""
     bmi = BmiStructuredQuadrilateral()
     grid = StructuredQuadrilateral(bmi, grid_id)
+
+    assert isinstance(grid, xr.Dataset)
+    assert grid.ndim == 2
+    assert grid.metadata["type"] == bmi.grid_type(grid_id)
+    assert grid.data_vars["mesh"].attrs["type"] == bmi.grid_type(grid_id)
+    assert type(grid.data_vars["node_x"].data) == np.ndarray
+
+
+class BmiUniformRectilinear():
+
+    shape = (4, 3)
+    spacing = (1., 1.)
+    origin = (5., 2.)
+
+    def grid_type(self, grid_id):
+        return "uniform_rectilinear"
+
+    def grid_ndim(self, grid_id):
+        return len(self.shape)
+
+    def grid_shape(self, grid_id, out=None):
+        return np.array(self.shape)
+
+    def grid_spacing(self, grid_id, out=None):
+        return np.array(self.spacing)
+
+    def grid_origin(self, grid_id, out=None):
+        return np.array(self.origin)
+
+
+def test_uniform_rectilinear_grid():
+    """Test creating a uniform rectilinear grid."""
+    bmi = BmiUniformRectilinear()
+    grid = UniformRectilinear(bmi, grid_id)
 
     assert isinstance(grid, xr.Dataset)
     assert grid.ndim == 2

--- a/tests/framework/test_bmi_ugrid.py
+++ b/tests/framework/test_bmi_ugrid.py
@@ -2,7 +2,8 @@
 import xarray as xr
 import numpy as np
 
-from pymt.framework.bmi_ugrid import Scalar, Vector, Points, Unstructured
+from pymt.framework.bmi_ugrid import (Scalar, Vector, Points,
+                                      Unstructured, StructuredQuadrilateral)
 
 
 grid_id = 0
@@ -90,4 +91,34 @@ def test_unstructured_grid():
     assert grid.ndim == 2
     assert grid.metadata["type"] == "unstructured"
     assert grid.data_vars["mesh"].attrs["type"] == "unstructured"
+    assert type(grid.data_vars["node_x"].data) == np.ndarray
+
+
+class TestStructuredQuadrilateral():
+
+    x = np.array([[0.,3.], [1.,4.], [2.,5.]])
+    y = np.array([[0.,1.], [2.,3.], [4.,5.]])
+
+    def grid_ndim(self, grid_id):
+        return self.x.ndim
+
+    def grid_shape(self, grid_id, out=None):
+        return np.array(self.x.shape)
+
+    def grid_x(self, grid_id, out=None):
+        return self.x.flatten()
+
+    def grid_y(self, grid_id, out=None):
+        return self.y.flatten()
+
+
+def test_structured_quadrilateral_grid():
+    """Test creating a structured quadrilateral grid."""
+    bmi = TestStructuredQuadrilateral()
+    grid = StructuredQuadrilateral(bmi, grid_id)
+
+    assert isinstance(grid, xr.Dataset)
+    assert grid.ndim == 2
+    assert grid.metadata["type"] == "structured_quadrilateral"
+    assert grid.data_vars["mesh"].attrs["type"] == "structured_quadrilateral"
     assert type(grid.data_vars["node_x"].data) == np.ndarray

--- a/tests/framework/test_bmi_ugrid.py
+++ b/tests/framework/test_bmi_ugrid.py
@@ -9,7 +9,7 @@ from pymt.framework.bmi_ugrid import (Scalar, Vector, Points,
 grid_id = 0
 
 
-class TestScalar:
+class BmiScalar:
 
     def grid_ndim(self, grid_id):
         return 0
@@ -17,7 +17,7 @@ class TestScalar:
 
 def test_scalar_grid():
     """Test creating a scalar grid."""
-    bmi = TestScalar()
+    bmi = BmiScalar()
     grid = Scalar(bmi, grid_id)
 
     assert grid.ndim == 0
@@ -26,7 +26,7 @@ def test_scalar_grid():
     assert isinstance(grid, xr.Dataset)
 
 
-class TestVector:
+class BmiVector:
 
     def grid_ndim(self, grid_id):
         return 1
@@ -34,7 +34,7 @@ class TestVector:
 
 def test_vector_grid():
     """Test creating a vector grid."""
-    bmi = TestVector()
+    bmi = BmiVector()
     grid = Vector(bmi, grid_id)
 
     assert grid.ndim == 1
@@ -43,7 +43,7 @@ def test_vector_grid():
     assert isinstance(grid, xr.Dataset)
 
 
-class TestPoints:
+class BmiPoints:
 
     x = np.array([0., 1., 0., 1.])
     y = np.array([0., 0., 1., 1.])
@@ -60,7 +60,7 @@ class TestPoints:
 
 def test_points_grid():
     """Test creating a grid from points."""
-    bmi = TestPoints()
+    bmi = BmiPoints()
     grid = Points(bmi, grid_id)
 
     assert isinstance(grid, xr.Dataset)
@@ -70,7 +70,7 @@ def test_points_grid():
     assert type(grid.data_vars["node_x"].data) == np.ndarray
 
 
-class TestUnstructured(TestPoints):
+class BmiUnstructured(BmiPoints):
 
     def grid_nodes_per_face(self, grid_id, out=None):
         return 4
@@ -85,7 +85,7 @@ class TestUnstructured(TestPoints):
 
 def test_unstructured_grid():
     """Test creating an unstructured grid."""
-    bmi = TestUnstructured()
+    bmi = BmiUnstructured()
     grid = Unstructured(bmi, grid_id)
 
     assert isinstance(grid, xr.Dataset)
@@ -95,7 +95,7 @@ def test_unstructured_grid():
     assert type(grid.data_vars["node_x"].data) == np.ndarray
 
 
-class TestStructuredQuadrilateral():
+class BmiStructuredQuadrilateral():
 
     x = np.array([[0., 3.], [1., 4.], [2., 5.]])
     y = np.array([[0., 1.], [2., 3.], [4., 5.]])
@@ -115,7 +115,7 @@ class TestStructuredQuadrilateral():
 
 def test_structured_quadrilateral_grid():
     """Test creating a structured quadrilateral grid."""
-    bmi = TestStructuredQuadrilateral()
+    bmi = BmiStructuredQuadrilateral()
     grid = StructuredQuadrilateral(bmi, grid_id)
 
     assert isinstance(grid, xr.Dataset)

--- a/tests/framework/test_bmi_ugrid.py
+++ b/tests/framework/test_bmi_ugrid.py
@@ -1,18 +1,20 @@
 """Unit tests for the pymt.framwork.bmi_ugrid module."""
-import xarray as xr
 import numpy as np
+import xarray as xr
 
-from pymt.framework.bmi_ugrid import (Scalar, Vector, Points,
-                                      Unstructured,
-                                      StructuredQuadrilateral,
-                                      UniformRectilinear)
-
+from pymt.framework.bmi_ugrid import (
+    Points,
+    Scalar,
+    StructuredQuadrilateral,
+    UniformRectilinear,
+    Unstructured,
+    Vector,
+)
 
 grid_id = 0
 
 
 class BmiScalar:
-
     def grid_type(self, grid_id):
         return "scalar"
 
@@ -32,7 +34,6 @@ def test_scalar_grid():
 
 
 class BmiVector:
-
     def grid_type(self, grid_id):
         return "vector"
 
@@ -53,8 +54,8 @@ def test_vector_grid():
 
 class BmiPoints:
 
-    x = np.array([0., 1., 0., 1.])
-    y = np.array([0., 0., 1., 1.])
+    x = np.array([0.0, 1.0, 0.0, 1.0])
+    y = np.array([0.0, 0.0, 1.0, 1.0])
 
     def grid_type(self, grid_id):
         return "points"
@@ -82,7 +83,6 @@ def test_points_grid():
 
 
 class BmiUnstructured(BmiPoints):
-
     def grid_type(self, grid_id):
         return "unstructured"
 
@@ -109,10 +109,10 @@ def test_unstructured_grid():
     assert type(grid.data_vars["node_x"].data) == np.ndarray
 
 
-class BmiStructuredQuadrilateral():
+class BmiStructuredQuadrilateral:
 
-    x = np.array([[0., 3.], [1., 4.], [2., 5.]])
-    y = np.array([[0., 1.], [2., 3.], [4., 5.]])
+    x = np.array([[0.0, 3.0], [1.0, 4.0], [2.0, 5.0]])
+    y = np.array([[0.0, 1.0], [2.0, 3.0], [4.0, 5.0]])
 
     def grid_type(self, grid_id):
         return "structured_quadrilateral"
@@ -142,11 +142,11 @@ def test_structured_quadrilateral_grid():
     assert type(grid.data_vars["node_x"].data) == np.ndarray
 
 
-class BmiUniformRectilinear():
+class BmiUniformRectilinear:
 
     shape = (4, 3)
-    spacing = (1., 1.)
-    origin = (5., 2.)
+    spacing = (1.0, 1.0)
+    origin = (5.0, 2.0)
 
     def grid_type(self, grid_id):
         return "uniform_rectilinear"

--- a/tests/framework/test_bmi_ugrid.py
+++ b/tests/framework/test_bmi_ugrid.py
@@ -14,6 +14,7 @@ class TestScalar:
     def grid_ndim(self, grid_id):
         return 0
 
+
 def test_scalar_grid():
     """Test creating a scalar grid."""
     bmi = TestScalar()
@@ -96,8 +97,8 @@ def test_unstructured_grid():
 
 class TestStructuredQuadrilateral():
 
-    x = np.array([[0.,3.], [1.,4.], [2.,5.]])
-    y = np.array([[0.,1.], [2.,3.], [4.,5.]])
+    x = np.array([[0., 3.], [1., 4.], [2., 5.]])
+    y = np.array([[0., 1.], [2., 3.], [4., 5.]])
 
     def grid_ndim(self, grid_id):
         return self.x.ndim


### PR DESCRIPTION
In this PR, I attempted to factor out repeated code in the *pymt.framework.bmi_ugrid* module, while rewriting the set of functions in the module as classes. I also added the ability to handle the `structured_quadrilateral` BMI grid type, which fixes #88. I included unit tests for each new class.