### PR TITLE
Install cfunits xml data

### DIFF
--- a/pymt/cfunits/units.py
+++ b/pymt/cfunits/units.py
@@ -2226,21 +2226,21 @@ array([-31., -30., -29., -28., -27.])
             # Convert an integer numpy array to a float numpy array
             # ----------------------------------------------------------------
             if inplace:
-                if x.dtype.kind is "i":
-                    if x.dtype.char is "i":
+                if x.dtype.kind == "i":
+                    if x.dtype.char == "i":
                         y = x.view(dtype="float32")
                         y[...] = x
                         x.dtype = numpy_dtype("float32")
-                    elif x.dtype.char is "l":
+                    elif x.dtype.char == "l":
                         y = x.view(dtype=float)
                         y[...] = x
                         x.dtype = numpy_dtype(float)
             else:
                 # At numpy vn1.7 astype has many more keywords ...
-                if x.dtype.kind is "i":
-                    if x.dtype.char is "i":
+                if x.dtype.kind == "i":
+                    if x.dtype.char == "i":
                         x = x.astype("float32")
-                    elif x.dtype.char is "l":
+                    elif x.dtype.char == "l":
                         x = x.astype(float)
                 else:
                     x = x.copy()

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     url="http://csdms.colorado.edu",
     python_requires=">=3.6",
     install_requires=open("requirements.txt", "r").read().splitlines(),
+    include_package_data=True,
     setup_requires=[],
     classifiers=[
         "Intended Audience :: Science/Research",


### PR DESCRIPTION
This pull request installs the *pymt*-embedded *cfunits* xml data files with the package. Without these data files, *cfunits* would report an error about Sverdrups (Sv).

```python
Traceback (most recent call last):
...
    assert 0 == _ut_unmap_symbol_to_unit(_ut_system, _c_char_p(b"Sv"), _UT_ASCII)
AssertionError
```

I've also fixed on *SyntaxWarnings* with *cfunits* that warned about using `is` with literal comparisons rather than `==`.