### PR TITLE
Use micromamba for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_install:
 install:
 - pip install cython numpy
 - micromamba install esmpy udunits2 --yes -c conda-forge
-- pip install -e .
+- python setup.py install
 script:
 - pip install -r requirements-testing.txt
 - pytest --cov=pymt --cov-report=xml:$(pwd)/coverage.xml -vvv

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
 - micromamba install python=$PYTHON pip mamba --yes -c conda-forge
 install:
 - mamba install esmpy udunits2 --yes -c conda-forge
-- pip install .
+- pip install -e .
 script:
 - pip install -r requirements-testing.txt
 - pytest --cov=pymt --cov-report=xml:$(pwd)/coverage.xml -vvv

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,27 +25,22 @@ before_install:
   fi
 - |
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh > $HOME/miniconda.sh
+    wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
   else
-    curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh > $HOME/miniconda.sh
+    wget -qO- https://micromamba.snakepit.net/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
   fi
-- bash $HOME/miniconda.sh -b -p $HOME/anaconda
-- export PATH="$HOME/anaconda/bin:$PATH"
-- conda init bash
-- hash -r
+- ./bin/micromamba shell init -s bash -p ~/micromamba
 - |
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     source $HOME/.bash_profile
   else
     source $HOME/.bashrc
   fi
-- conda config --set always_yes yes --set changeps1 no
-- conda create -n _testing python=$PYTHON
-- conda activate _testing
-- conda info -a && conda list
+- micromamba activate
+- micromamba install python=$PYTHON -c conda-forge
 install:
 - pip install cython numpy
-- conda install esmpy udunits2 -c conda-forge
+- micromamba install esmpy udunits2 -c conda-forge
 - pip install -e .
 script:
 - pip install -r requirements-testing.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ before_install:
   fi
 - |
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
-  else
     wget -qO- https://micromamba.snakepit.net/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
+  else
+    wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
   fi
 - ./bin/micromamba shell init -s bash -p ~/micromamba
 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,6 @@ jobs:
     - make lint
 before_install:
 - |
-  if [[ $TRAVIS_OS_NAME == "osx" ]]; then
-    brew remove --force $(brew list)
-    brew cleanup -s
-    rm -rf $(brew --cache)
-  fi
-- |
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     wget -qO- https://micromamba.snakepit.net/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
   else
@@ -31,16 +25,22 @@ before_install:
   fi
 - ./bin/micromamba shell init -s bash -p ~/micromamba
 - |
+  if [[ $TRAVIS_OS_NAME == "osx" ]]; then
+    brew remove --force $(brew list)
+    brew cleanup -s
+    rm -rf $(brew --cache)
+  fi
+- |
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     source $HOME/.bash_profile
   else
     source $HOME/.bashrc
   fi
 - micromamba activate
-- micromamba install python=$PYTHON -c conda-forge
+- micromamba install python=$PYTHON --yes -c conda-forge
 install:
 - pip install cython numpy
-- micromamba install esmpy udunits2 -c conda-forge
+- micromamba install esmpy udunits2 --yes -c conda-forge
 - pip install -e .
 script:
 - pip install -r requirements-testing.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,6 @@ jobs:
     - make lint
 before_install:
 - |
-  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    wget -qO- https://micromamba.snakepit.net/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
-  else
-    wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
-  fi
-- ./bin/micromamba shell init -s bash -p ~/micromamba
-- |
   if [[ $TRAVIS_OS_NAME == "osx" ]]; then
     brew remove --force $(brew list)
     brew cleanup -s
@@ -32,16 +25,23 @@ before_install:
   fi
 - |
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    curl -L https://micromamba.snakepit.net/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
+  else
+    curl -L https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+  fi
+- ./bin/micromamba shell init -s bash -p ~/micromamba
+- |
+  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     source $HOME/.bash_profile
   else
     source $HOME/.bashrc
   fi
 - micromamba activate
-- micromamba install python=$PYTHON pip --yes -c conda-forge
+- micromamba install python=$PYTHON pip mamba --yes -c conda-forge
 install:
 - pip install cython numpy
-- micromamba install esmpy udunits2 --yes -c conda-forge
-- python setup.py install
+- mamba install esmpy udunits2 --yes -c conda-forge
+- pip install .
 script:
 - pip install -r requirements-testing.txt
 - pytest --cov=pymt --cov-report=xml:$(pwd)/coverage.xml -vvv

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ before_install:
 - micromamba activate
 - micromamba install python=$PYTHON pip mamba --yes -c conda-forge
 install:
-- pip install cython numpy
 - mamba install esmpy udunits2 --yes -c conda-forge
 - pip install .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
     source $HOME/.bashrc
   fi
 - micromamba activate
-- micromamba install python=$PYTHON --yes -c conda-forge
+- micromamba install python=$PYTHON pip --yes -c conda-forge
 install:
 - pip install cython numpy
 - micromamba install esmpy udunits2 --yes -c conda-forge

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Changelog for pymt
 
 - Documentation improvements
 
+- Use mamba for our continuous integration (#122)
+
 
 1.1.3 (2020-04-23)
 ------------------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,6 @@ environment:
 platform:
   - x64
 
-# os: Previous Visual Studio 2015
 os: Visual Studio 2019
 
 init:
@@ -23,10 +22,9 @@ init:
 
 install:
   - cmd: call %MINICONDA%\Scripts\activate.bat
-  - cmd: conda update --yes --quiet conda
-  - cmd: set PYTHONUNBUFFERED=1
-  - cmd: conda config --set always_yes yes
   - cmd: conda install mamba -c conda-forge
+  - cmd: set PYTHONUNBUFFERED=1
+  - cmd: mamba config --set always_yes yes
   - cmd: mamba install geos udunits2 -c conda-forge
   - cmd: mamba list
   - cmd: python --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ platform:
   - x64
 
 # os: Previous Visual Studio 2015
+os: Visual Studio 2019
 
 init:
   - "ECHO %PYTHON% %HOME% %PLATFORM%"
@@ -25,7 +26,7 @@ install:
   - cmd: conda update --yes --quiet conda
   - cmd: set PYTHONUNBUFFERED=1
   - cmd: conda config --set always_yes yes
-  - cmd: conda install mamba
+  - cmd: conda install mamba -c conda-forge
   - cmd: mamba install geos udunits2 -c conda-forge
   - cmd: mamba list
   - cmd: python --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,9 @@ environment:
 
   matrix:
 
+    - PYTHON: "3.8"
+      MINICONDA: C:\\Miniconda38-x64
+
     - PYTHON: "3.7"
       MINICONDA: C:\\Miniconda37-x64
 
@@ -22,14 +25,14 @@ install:
   - cmd: conda update --yes --quiet conda
   - cmd: set PYTHONUNBUFFERED=1
   - cmd: conda config --set always_yes yes
-  - cmd: conda install geos udunits2 -c conda-forge
-  - cmd: conda list
+  - cmd: conda install mamba
+  - cmd: mamba install geos udunits2 -c conda-forge
+  - cmd: mamba list
   - cmd: python --version
 
 build: false
 
 test_script:
-  - cmd: pip install cython numpy
   - cmd: pip install -r requirements-testing.txt
   - cmd: pip install -e .
   - cmd: pytest -vvv

--- a/docs/conda-environments.rst
+++ b/docs/conda-environments.rst
@@ -18,19 +18,19 @@ side-by-side installations of Python, one for each project.  It doesn't actually
 install separate copies of Python, but it does provide a clever way to
 keep different project environments isolated.
 
-If you are on Mac or Linux, and have *conda* installed, from a terminal you
+If you are on Mac or Linux, and have *mamba* installed, from a terminal you
 can run the following to create a new Python environment,
 
 .. code-block:: bash
 
-  $ conda create -n myproject python
+  $ mamba create -n myproject python
 
 Now, whenever you want to work on a project, you only have to activate the
 corresponding environment.  On OS X and Linux, do the following,
 
 .. code-block:: bash
 
-  $ conda activate myproject
+  $ mamba activate myproject
 
 To get out of the environment,
 
@@ -42,12 +42,12 @@ To remove the environment,
 
 .. code-block:: bash
 
-  $ conda remove -n myproject --all
+  $ mamba remove -n myproject --all
 
 With this environment activated, you can install *pymt* into it with the
 following,
 
 .. code-block:: bash
 
-  $ conda install pymt -c conda-forge
+  $ mamba install pymt -c conda-forge
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,6 @@ class Mock(MagicMock):
 
 
 MOCK_MODULES = [
-    "cfunits",
     "ESMF",
     "landlab",
     "landlab.graph",
@@ -103,7 +102,6 @@ extensions = [
     "sphinx.ext.autosummary",
     "nbsphinx",
     "IPython.sphinxext.ipython_console_highlighting",
-    "sphinxcontrib_github_alt",
 
 ]
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -84,6 +84,11 @@ can be found in the `Python Glossary`_.
 
       See :term:`object`.
 
+   mamba
+
+      A faster, open-source alternative to the :term:`conda` package
+      manager.
+
    Matplotlib
 
       A Python plotting library used in *pymt*. For more information,

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -35,10 +35,10 @@ Install *pymt* into this conda environment with:
 
 .. code-block:: console
 
-    $ conda install pymt
+    $ mamba install pymt
 
 Note that *pymt* is built on several open source software
-libraries, so it may take a few minutes for conda to find,
+libraries, so it may take a few minutes for *mamba* to find,
 download, and install them.
 
 .. include:: installation-check.rst
@@ -71,13 +71,13 @@ you created above:
 
 .. code-block:: console
 
-    $ conda install --file=requirements.txt
+    $ mamba install --file=requirements.txt
 
 Then install *pymt* with:
 
 .. code-block:: console
 
-    $ python setup.py install
+    $ pip install -e .
 
 .. include:: installation-check.rst
 

--- a/docs/installation-environment.rst
+++ b/docs/installation-environment.rst
@@ -1,14 +1,22 @@
-We strongly recommend using :term:`conda` to install and run *pymt*. If
-you don't have conda installed, the `Anaconda installation guide`_
+We strongly recommend using :term:`mamba` to install and run *pymt*. If
+you don't have *mamba* installed, the `Anaconda installation guide`_
 can help you through the process.
 
-Once you've installed conda,
+Once you've installed *Anaconda*/*conda*, we suggest using the
+`mamba`_ package manager.  *mamba* is pretty much the same as *conda*,
+only faster. If you would rather stick with *conda*, just
+replace occurances of *mamba* with *conda*.
+
+.. code-block:: console
+
+    $ conda install mamba
+
 add the :term:`conda-forge` channel
 to the list of enabled conda channels on your machine:
 
 .. code-block:: console
 
-    $ conda config --add channels conda-forge
+    $ mamba config --add channels conda-forge
 
 We advise installing *pymt* into a :term:`conda environment`.
 Conda environments can easily be created and discarded.
@@ -16,12 +24,14 @@ Create an environment for *pymt* with:
 
 .. code-block:: console
 
-    $ conda create -n pymt python=3
+    $ mamba create -n pymt python=3
 
 Once the conda environment has been created, activate it with:
 
 .. code-block:: console
 
-    $ source activate pymt
+    $ conda activate pymt
 
 .. _Anaconda installation guide: http://docs.anaconda.com/anaconda/install/
+
+.. _mamba: https://medium.com/@QuantStack/open-software-packaging-for-science-61cecee7fc23

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -13,24 +13,30 @@ and explain what occurred.
 .. _CSDMS Help Desk: https://github.com/csdms/help-desk
 
 
-Install conda
--------------
+Install conda/mamba
+-------------------
 
 :term:`Anaconda` is a free, open-source, Python distribution
 that contains a comprehensive set of packages for scientific computing.
 If you don't have conda installed, the `Anaconda installation guide`_
 can help you through the process.
 
+Once you've installed *conda*, we suggest installing :term:*mamba* to
+install additional packages.
+
+.. code-block:: bash
+
+  $ conda install mamba -c conda-forge 
 
 Install *pymt*
 --------------
 
-Once you've installed conda,
+Once you've installed *mamba*,
 You can get *pymt* directly from :term:`conda-forge`:
 
 .. code-block:: bash
 
-  $ conda install pymt -c conda-forge 
+  $ mamba install pymt -c conda-forge 
 
 Installing into a :term:`conda environment` is strongly recommended.
 Check the :doc:`installation guide<install>` for more detailed
@@ -49,7 +55,7 @@ Install Hydrotrend into *pymt* with:
 
 .. code-block:: console
 
-    $ conda install pymt_hydrotrend -c conda-forge
+    $ mamba install pymt_hydrotrend -c conda-forge
 
 Check that the model has been installed by starting a Python
 session and importing *pymt*:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -16,7 +16,7 @@ Install them with:
 
 .. code-block:: console
 
-    $ conda install pymt_cem
+    $ mamba install pymt_cem -c conda-forge
 
 
 Loading *pymt*


### PR DESCRIPTION
This pull request uses *micromamba* and *mamba* in place of *conda*/*miniconda* for our CI both on *Travis* and *AppVeyor*. *mamba* faster than *conda* as well as Open Source.