### PR TITLE
Check if unstructured mesh has only triangular faces

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for pymt
 1.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed an issue in quick_plot when trying to plot unstructured meshes (#127)
 
 
 1.2.1 (2020-09-22)

--- a/pymt/framework/bmi_plot.py
+++ b/pymt/framework/bmi_plot.py
@@ -8,9 +8,6 @@ def quick_plot(bmi, name, **kwds):
     gtype = bmi.grid_type(gid)
     grid = bmi.grid[gid]
 
-    x, y = grid.node_x.values, grid.node_y.values
-    z = bmi.get_value(name)
-
     x_label = "{name} ({units})".format(
         name=grid.node_x.standard_name, units=grid.node_x.units
     )
@@ -18,9 +15,17 @@ def quick_plot(bmi, name, **kwds):
         name=grid.node_y.standard_name, units=grid.node_y.units
     )
 
-    if gtype in ("unstructured_triangular",):
-        tris = bmi.grid_face_node_connectivity(gid).reshape((-1, 3))
-        plt.tripcolor(x, y, tris, z, **kwds)
+    z = bmi.get_value(name)
+
+    if gtype.startswith("unstructured"):
+        x, y = grid.node_x.values, grid.node_y.values
+        nodes_per_face = bmi.grid_nodes_per_face(gid)
+        if np.all(nodes_per_face == 3):
+            tris = bmi.grid_face_nodes(gid).reshape((-1, 3))
+            # tris = bmi.grid_face_node_connectivity(gid).reshape((-1, 3))
+            plt.tripcolor(x, y, tris, z, **kwds)
+        else:
+            raise ValueError("quickplot is only able to plot unstructured meshes of triangles")
     elif gtype in ("uniform_rectilinear", "structured_quad"):
         shape = bmi.grid_shape(gid)
         spacing = bmi.grid_spacing(gid)


### PR DESCRIPTION
This pull request fixes an issue in *quickplot* when it's given an *unstructured* mesh. Previously, the grid type, as returned by a BMI, had to be *unstructured_triangular* but that's no longer a valid grid type. Now, *quickplot* understands *unstructured* but then checks to ensure that all faces have exactly 3 edges. If they don't, an exception is raised.