### PR TITLE
Add citation file for pymt

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,42 @@
+# YAML 1.2
+---
+authors: 
+  -
+    family-names: Hutton
+    given-names: Eric
+    orcid: "https://orcid.org/0000-0002-5864-6459"
+  -
+    family-names: Piper
+    given-names: Mark
+    orcid: "https://orcid.org/0000-0001-6418-277X"
+  -
+    family-names: Drost
+    given-names: Niels
+    orcid: "https://orcid.org/0000-0001-9795-7981"
+  -
+    family-names: Gan
+    given-names: Tian
+    orcid: "https://orcid.org/0000-0003-3624-6910"
+  -
+    family-names: Kettner
+    given-names: Albert
+    orcid: "https://orcid.org/0000-0002-7191-6521"
+  -
+    family-names: Overeem
+    given-names: Irina
+    orcid: "https://orcid.org/0000-0002-8422-580X"
+  -
+    family-names: Stewart
+    given-names: Scott
+  -
+    family-names: Wang
+    given-names: Kang
+    orcid: "https://orcid.org/0000-0003-3416-572X"
+cff-version: "1.1.0"
+date-released: 2021-03-18
+doi: "10.5281/zenodo.4985222"
+license: MIT
+message: "If you use this software, please cite it using these metadata."
+title: "The Python Modeling Toolkit (PyMT)"
+version: "1.3.1"
+...


### PR DESCRIPTION
I've added a citation file for the *pymt* in the [Citation File Format](https://citation-file-format.github.io/).