### PR TITLE
Use Python 3 class style

### DIFF
--- a/deprecated/component_info.py
+++ b/deprecated/component_info.py
@@ -138,7 +138,7 @@ def mapping_to_config_value(mapping):
     return ",".join(map_pairs)
 
 
-class ComponentInfo(object):
+class ComponentInfo:
     _keys = {
         "str": set(["output_file_namespace", "config_xml_file", "initialize_arg"]),
         "list": set(["mappers", "ports", "optional_ports", "init_ports"]),

--- a/deprecated/grids/vtk_mixin.py
+++ b/deprecated/grids/vtk_mixin.py
@@ -8,13 +8,13 @@ try:
 except ImportError:
     warnings.warn("vtk is not installed")
 
-    class VtkGridMixIn(object):
+    class VtkGridMixIn:
         pass
 
 
 else:
 
-    class VtkGridMixIn(object):
+    class VtkGridMixIn:
         _EDGE_COUNT_TO_TYPE = {
             1: tvtk.Vertex().cell_type,
             2: tvtk.Line().cell_type,

--- a/deprecated/ordered_task_status.py
+++ b/deprecated/ordered_task_status.py
@@ -28,7 +28,7 @@ import six
 from pymt.task_status import TaskStatus
 
 
-class OrderedTaskStatus(object):
+class OrderedTaskStatus:
     """OrderedTaskStatus([task, [status]])
 
     >>> status = OrderedTaskStatus()

--- a/deprecated/printers/bov/database.py
+++ b/deprecated/printers/bov/database.py
@@ -5,7 +5,7 @@ import os
 from .bov_io import tofile
 
 
-class IDatabase(object):
+class IDatabase:
     def __init__(self):
         pass
 
@@ -21,7 +21,7 @@ class IDatabase(object):
 
 class Database(IDatabase):
     def __init__(self):
-        super(Database, self).__init__()
+        super().__init__()
 
         self._var_name = ""
         self._path = ""

--- a/deprecated/printers/vtk/encoders.py
+++ b/deprecated/printers/vtk/encoders.py
@@ -16,12 +16,12 @@ class UnknownEncoder(EncoderError):
         return "%s: Unknown encoder" % self._name
 
 
-class Encoder(object):
+class Encoder:
     def encode(self, array):
         pass
 
 
-class ASCIIEncoder(object):
+class ASCIIEncoder:
     def encode(self, array):
         try:
             return " ".join([str(val) for val in array.flatten()])
@@ -29,7 +29,7 @@ class ASCIIEncoder(object):
             return " ".join([str(val) for val in array])
 
 
-class RawEncoder(object):
+class RawEncoder:
     def encode(self, array):
         try:
             as_str = array.tostring()
@@ -39,7 +39,7 @@ class RawEncoder(object):
         return block_size + as_str
 
 
-class Base64Encoder(object):
+class Base64Encoder:
     def encode(self, array):
         try:
             as_str = array.tostring()

--- a/deprecated/printers/vtk/vtktypes.py
+++ b/deprecated/printers/vtk/vtktypes.py
@@ -3,7 +3,7 @@
 from .encoders import ASCIIEncoder, Base64Encoder, RawEncoder
 
 
-class VtkEndian(object):
+class VtkEndian:
     def __init__(self, endian):
         self.name = endian
 
@@ -17,7 +17,7 @@ VtkBigEndian = VtkEndian("BigEndian")
 sys_to_vtk_endian = {"little": VtkLittleEndian, "big": VtkBigEndian}
 
 
-class VtkType(object):
+class VtkType:
     def __init__(self, name, size):
         self.bytes = size
         self.name = name
@@ -48,7 +48,7 @@ vtk_to_np_type = {
 }
 
 
-class VtkCellType(object):
+class VtkCellType:
     def __init__(self, name, id):
         self.id = id
         self.name = name
@@ -69,7 +69,7 @@ VtkPolygon = VtkCellType("Polygon", 7)
 edge_count_to_type = {1: VtkVertex, 2: VtkLine, 3: VtkTriangle, 4: VtkQuad}
 
 
-class VtkGridType(object):
+class VtkGridType:
     def __init__(self, name):
         self.name = name
 

--- a/deprecated/printers/vtk/vtkxml.py
+++ b/deprecated/printers/vtk/vtkxml.py
@@ -9,7 +9,7 @@ from .encoders import encode
 from .vtktypes import np_to_vtk_type, sys_to_vtk_endian
 
 
-class VtkExtent(object):
+class VtkExtent:
     def __init__(self, shape):
         if len(shape) > 3:
             raise ValueError("number of dimension must be <= 3")
@@ -28,7 +28,7 @@ class VtkExtent(object):
         return self._extent_str
 
 
-class VtkOrigin(object):
+class VtkOrigin:
     def __init__(self, origin, spacing):
         if len(origin) > 3 or len(spacing) > 3:
             raise ValueError("number of dimension must be <= 3")
@@ -51,7 +51,7 @@ class VtkOrigin(object):
         return self._origin_str
 
 
-class VtkSpacing(object):
+class VtkSpacing:
     def __init__(self, spacing):
         if len(spacing) > 3:
             raise ValueError("number of dimension must be <= 3")

--- a/deprecated/printers/vtk/vtu.py
+++ b/deprecated/printers/vtk/vtu.py
@@ -131,7 +131,7 @@ def tofile(field, path, **kwds):
         f.write(doc.toprettyxml())
 
 
-class IDatabase(object):
+class IDatabase:
     def __init__(self):
         pass
 
@@ -151,7 +151,7 @@ class Database(IDatabase):
         self._path = ""
         self._template = ""
 
-        super(Database, self).__init__()
+        super().__init__()
 
     def open(self, path, var_name):
         try:
@@ -187,7 +187,7 @@ class Database(IDatabase):
             pass
 
 
-class VtkDatabase(object):
+class VtkDatabase:
     def __init__(self, field):
         self._field = field
         self._count = 0

--- a/deprecated/status.py
+++ b/deprecated/status.py
@@ -17,7 +17,7 @@ Initialized
 """
 
 
-class Status(object):
+class Status:
     def __init__(self, string, val):
         self.string = string
         self.val = val

--- a/deprecated/task_status.py
+++ b/deprecated/task_status.py
@@ -59,7 +59,7 @@ def task_as_integer(task):
         return task_as_valid_integer(task)
 
 
-class TaskStatus(object):
+class TaskStatus:
     def __init__(
         self,
         name,

--- a/deprecated/utils/decorators.py
+++ b/deprecated/utils/decorators.py
@@ -5,7 +5,7 @@ import warnings
 from functools import wraps
 
 
-class cache_result_in_object(object):
+class cache_result_in_object:
     def __init__(self, cache_as=None):
         self._attr = cache_as
 
@@ -21,7 +21,7 @@ class cache_result_in_object(object):
         return _wrapped
 
 
-class deprecated(object):
+class deprecated:
 
     """Mark a function as deprecated."""
 

--- a/deprecated/utils/run_dir.py
+++ b/deprecated/utils/run_dir.py
@@ -3,7 +3,7 @@ import tempfile
 import shutil
 
 
-class cd(object):
+class cd:
     def __init__(self, path, create=False):
         self._dir = os.path.abspath(path)
         self._starting_dir = os.path.abspath(os.getcwd())
@@ -19,7 +19,7 @@ class cd(object):
         os.chdir(self._starting_dir)
 
 
-class cd_temp(object):
+class cd_temp:
     """Create a temporary directory and change to it.
 
     Parameters
@@ -60,7 +60,7 @@ class cd_temp(object):
         shutil.rmtree(self._dir)
 
 
-class RunDir(object):
+class RunDir:
     def __init__(self, directory, create=False):
         self._run_dir = directory
         self._create = create

--- a/deprecated/utils/verbose.py
+++ b/deprecated/utils/verbose.py
@@ -52,7 +52,7 @@ class CmtLogger(logging.Logger):
         self.addHandler(ch)
 
 
-class Verbose(object):
+class Verbose:
     def __init__(self, verbosity=0, log=sys.stderr):
         self._verbosity = verbosity
         self._log = log

--- a/pymt/bmi/bmi.py
+++ b/pymt/bmi/bmi.py
@@ -14,7 +14,7 @@ class VarNameError(Error):
         return self.name
 
 
-class BMI(object):
+class BMI:
     def initialize(self, filename):
         pass
 

--- a/pymt/cmd/cmt_config.py
+++ b/pymt/cmd/cmt_config.py
@@ -8,7 +8,7 @@ import yaml
 from model_metadata.find import find_model_data_files
 
 
-class redirect(object):
+class redirect:
     def __init__(self, stdout=None, stderr=None):
         self._stdout = sys.stdout
         self._stderr = sys.stderr

--- a/pymt/component/grid.py
+++ b/pymt/component/grid.py
@@ -64,7 +64,7 @@ def get_raster_node_coordinates(grid, grid_id):
     Examples
     --------
     >>> from pymt.component.grid import get_raster_node_coordinates
-    >>> class RasterGrid(object):
+    >>> class RasterGrid:
     ...     def get_grid_shape(self, grid_id):
     ...         return (2, 3)
     ...     def get_grid_spacing(self, grid_id):
@@ -107,7 +107,7 @@ def get_rectilinear_node_coordinates(grid, grid_id):
     Examples
     --------
     >>> from pymt.component.grid import get_rectilinear_node_coordinates
-    >>> class RectilinearGrid(object):
+    >>> class RectilinearGrid:
     ...     def get_grid_x(self, grid_id):
     ...         return (0., 3., 4)
     ...     def get_grid_y(self, grid_id):
@@ -150,7 +150,7 @@ def get_structured_node_coordinates(grid, grid_id):
     Examples
     --------
     >>> from pymt.component.grid import get_structured_node_coordinates
-    >>> class StructuredGrid(object):
+    >>> class StructuredGrid:
     ...     def get_grid_x(self, grid_id):
     ...         return np.array((0., 3., 4, 0., 3., 4.)).reshape((2, 3))
     ...     def get_grid_y(self, grid_id):
@@ -194,7 +194,7 @@ def get_structured_node_connectivity(grid, grid_id):
     Examples
     --------
     >>> from pymt.component.grid import get_structured_node_connectivity
-    >>> class StructuredGrid(object):
+    >>> class StructuredGrid:
     ...     def get_grid_shape(self, grid_id):
     ...         return (2, 3)
     >>> g = StructuredGrid()
@@ -208,12 +208,12 @@ def get_structured_node_connectivity(grid, grid_id):
     return get_connectivity(shape, with_offsets=True)
 
 
-class GridMixIn(object):
+class GridMixIn:
     """Mix-in that makes a Component grid-like.
 
     Examples
     --------
-    >>> class Port(object):
+    >>> class Port:
     ...     def get_component_name(self):
     ...         return 'test-component'
     ...     def get_input_item_count(self):
@@ -235,7 +235,7 @@ class GridMixIn(object):
     >>> class Component(GridMixIn):
     ...     def __init__(self):
     ...         self._port = Port()
-    ...         super(Component, self).__init__()
+    ...         super().__init__()
     >>> c = Component()
     >>> c.name
     'test-component'

--- a/pymt/component/model.py
+++ b/pymt/component/model.py
@@ -43,7 +43,7 @@ def get_exchange_item_mapping(items):
     return mapping
 
 
-class Model(object):
+class Model:
     def __init__(self, components, driver=None, duration=0.0):
         self._components = dict(components)
         self._driver = driver

--- a/pymt/events/chain.py
+++ b/pymt/events/chain.py
@@ -1,4 +1,4 @@
-class ChainEvent(object):
+class ChainEvent:
     def __init__(self, events):
         self._events = events
 

--- a/pymt/events/empty.py
+++ b/pymt/events/empty.py
@@ -6,7 +6,7 @@ you want to force the manager to stop at particular intervals.
 """
 
 
-class PassEvent(object):
+class PassEvent:
     """An event that doesn't do anything."""
 
     def initialize(self):

--- a/pymt/events/manager.py
+++ b/pymt/events/manager.py
@@ -17,7 +17,7 @@ Examples
 --------
 Create an event that prints, "hello".
 
->>> class PrintHello(object):
+>>> class PrintHello:
 ...     def initialize(self):
 ...         print("hello from initialize")
 ...     def run(self, time):
@@ -52,7 +52,7 @@ from ..timeline import Timeline
 from ..utils.prefix import names_with_prefix
 
 
-class EventManager(object):
+class EventManager:
     """
     Parameters
     ----------

--- a/pymt/events/port.py
+++ b/pymt/events/port.py
@@ -98,7 +98,7 @@ class PortEvent(GridMixIn):
         self._status_fp.close()
 
 
-class PortMapEvent(object):
+class PortMapEvent:
     """An event that maps values between ports.
 
     Parameters

--- a/pymt/events/printer.py
+++ b/pymt/events/printer.py
@@ -2,7 +2,7 @@ from ..portprinter.port_printer import PortPrinter
 from ..utils import as_cwd
 
 
-class PrintEvent(object):
+class PrintEvent:
     def __init__(self, *args, **kwds):
         # self._printer = PortPrinter.from_dict(kwds)
         self._run_dir = kwds.pop("run_dir", ".")

--- a/pymt/framework/bmi_bridge.py
+++ b/pymt/framework/bmi_bridge.py
@@ -24,7 +24,7 @@ from .bmi_ugrid import dataset_from_bmi_grid
 UNITS = gimli.units
 
 
-class DataValues(object):
+class DataValues:
     def __init__(self, bmi, name):
         self._bmi = bmi
         self._name = name
@@ -91,7 +91,7 @@ Attributes:
         ).strip()
 
 
-class _BmiCapV1(object):
+class _BmiCapV1:
 
     """Add methods for backward compatibility."""
 
@@ -130,7 +130,7 @@ class _BmiCapV1(object):
         return _BmiCapV1._call_bmi(self.bmi.get_grid_offset, grid, out)
 
 
-class _BmiCapV2(object):
+class _BmiCapV2:
     @deprecated(reason="use get_grid_number_of_vertices")
     def get_grid_vertex_count(self, grid):
         return self.grid_vertex_count(grid)
@@ -273,7 +273,7 @@ class _BmiCap(DeprecatedMethods):
         self._var = dict()
         self._time_units = None
         self._initdir = None
-        super(_BmiCap, self).__init__()
+        super().__init__()
 
     @property
     def bmi(self):

--- a/pymt/framework/bmi_mapper.py
+++ b/pymt/framework/bmi_mapper.py
@@ -153,7 +153,7 @@ def run_regridding(srcfield, dstfield, method="nearest", unmapped="pass"):
     return dstfield
 
 
-class GridMapperMixIn(object):
+class GridMapperMixIn:
     def _esmf_mesh_by_id(self, gid):
         try:
             self._esmf_mesh
@@ -245,7 +245,7 @@ class GridMapperMixIn(object):
             Name of the destination values.
         """
         if len(args) == 1:
-            return super(GridMapperMixIn, self).set_value(name, *args)
+            return super().set_value(name, *args)
 
         mapfrom = kwds.pop("mapfrom", self)
         nomap = kwds.pop("nomap", None)
@@ -262,7 +262,7 @@ class GridMapperMixIn(object):
         if nomap is not None:
             data[nomap] = orig[nomap]
 
-        super(GridMapperMixIn, self).set_value(name, data)
+        super().set_value(name, data)
 
     def map_value(self, name, **kwds):
         """Map values from another grid.

--- a/pymt/framework/bmi_setup.py
+++ b/pymt/framework/bmi_setup.py
@@ -20,7 +20,7 @@ def _parse_author_info(info):
     return tuple(author)
 
 
-class SetupMixIn(object):
+class SetupMixIn:
     def __init__(self):
         name = self.__class__.__name__.split(".")[-1]
 
@@ -126,7 +126,7 @@ class SetupMixIn(object):
         return self._meta.info["cite_as"]
 
 
-class GitHubSetupMixIn(object):
+class GitHubSetupMixIn:
     def setup(self, case="default", name=None, path=None):
         if name is None:
             try:

--- a/pymt/framework/bmi_timeinterp.py
+++ b/pymt/framework/bmi_timeinterp.py
@@ -4,7 +4,7 @@ from ..utils import as_cwd
 from .timeinterp import TimeInterpolator
 
 
-class BmiTimeInterpolator(object):
+class BmiTimeInterpolator:
     def __init__(self, *args, **kwds):
         method = kwds.pop("method", "linear")
         self._interpolators = dict(
@@ -12,7 +12,7 @@ class BmiTimeInterpolator(object):
         )
         self.reset(method=method)
 
-        super(BmiTimeInterpolator, self).__init__(*args, **kwds)
+        super().__init__(*args, **kwds)
 
     def reset(self, method="linear"):
         for name in self._interpolators:

--- a/pymt/framework/bmi_ugrid.py
+++ b/pymt/framework/bmi_ugrid.py
@@ -26,7 +26,7 @@ class _Base(xr.Dataset):
         self.grid_type = bmi.grid_type(grid_id)
         self.ndim = bmi.grid_ndim(grid_id)
         self.metadata = OrderedDict()
-        super(_Base, self).__init__()
+        super().__init__()
 
     def set_mesh(self):
         self.update({"mesh": xr.DataArray(data=self.grid_id, attrs=self.metadata)})
@@ -99,7 +99,7 @@ class Scalar(_Base):
     __slots__ = ()
 
     def __init__(self, *args):
-        super(Scalar, self).__init__(*args)
+        super().__init__(*args)
 
         if self.ndim != 0:
             raise ValueError("scalar must be rank 0")
@@ -119,7 +119,7 @@ class Vector(_Base):
     __slots__ = ()
 
     def __init__(self, *args):
-        super(Vector, self).__init__(*args)
+        super().__init__(*args)
 
         if self.ndim != 1:
             raise ValueError("vector must be rank 1")
@@ -139,7 +139,7 @@ class Points(_Base):
     __slots__ = ()
 
     def __init__(self, *args):
-        super(Points, self).__init__(*args)
+        super().__init__(*args)
 
         self.metadata = OrderedDict(
             [
@@ -158,7 +158,7 @@ class Unstructured(_Base):
     __slots__ = ()
 
     def __init__(self, *args):
-        super(Unstructured, self).__init__(*args)
+        super().__init__(*args)
 
         self.metadata = OrderedDict(
             [
@@ -179,7 +179,7 @@ class StructuredQuadrilateral(_Base):
     __slots__ = ()
 
     def __init__(self, *args):
-        super(StructuredQuadrilateral, self).__init__(*args)
+        super().__init__(*args)
 
         if self.ndim < 1 or self.ndim > 3:
             raise ValueError("structured_quadrilateral grid must be rank 1, 2, or 3")
@@ -216,7 +216,7 @@ class Rectilinear(_Base):
     __slots__ = ()
 
     def __init__(self, *args):
-        super(Rectilinear, self).__init__(*args)
+        super().__init__(*args)
 
         if self.ndim < 1 or self.ndim > 3:
             raise ValueError("rectilinear grid must be rank 1, 2, or 3")
@@ -253,7 +253,7 @@ class UniformRectilinear(_Base):
     __slots__ = ()
 
     def __init__(self, *args):
-        super(UniformRectilinear, self).__init__(*args)
+        super().__init__(*args)
 
         if self.ndim < 1 or self.ndim > 3:
             raise ValueError("uniform_rectangular grid must be rank 1, 2, or 3")

--- a/pymt/framework/timeinterp.py
+++ b/pymt/framework/timeinterp.py
@@ -15,7 +15,7 @@ _MINIMUM_SIZE_FOR_METHOD = {
 }
 
 
-class TimeInterpolator(object):
+class TimeInterpolator:
 
     METHODS = (
         "linear",

--- a/pymt/grids/esmp.py
+++ b/pymt/grids/esmp.py
@@ -245,7 +245,7 @@ class EsmpGrid(IGrid):
         self._mesh_add_nodes()
         self._mesh_add_elements()
 
-        super(EsmpGrid, self).__init__()
+        super().__init__()
 
     def get_point_count(self):
         raise NotImplementedError("get_point_count")
@@ -295,7 +295,7 @@ class EsmpUniformRectilinear(UniformRectilinear, EsmpStructured):
 
 class EsmpField(IField):
     def __init__(self, *args, **kwargs):
-        super(EsmpField, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._fields = {}
 
     def get_point_count(self):
@@ -338,9 +338,7 @@ class EsmpStructuredField(EsmpStructured, EsmpField):
             if val.ndim > 1 and np.any(val.shape != self.get_shape()):
                 raise DimensionError(val.shape, self.get_shape())
         try:
-            super(EsmpStructuredField, self).add_field(
-                field_name, val, centering=centering
-            )
+            super().add_field(field_name, val, centering=centering)
         except (DimensionError, CenteringValueError):
             raise
 

--- a/pymt/grids/field.py
+++ b/pymt/grids/field.py
@@ -24,7 +24,7 @@ def combine_args_to_list(*args, **kwds):
 
 class GridField(Unstructured, IField):
     def __init__(self, *args, **kwargs):
-        super(GridField, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._fields = {}
         self._field_units = {}
 
@@ -157,7 +157,7 @@ class StructuredField(Structured, GridField):
             if val.ndim > 1 and np.any(val.shape != self.get_shape()):
                 raise DimensionError(val.shape, self.get_shape())
         try:
-            super(StructuredField, self).add_field(
+            super().add_field(
                 field_name,
                 val,
                 centering=centering,

--- a/pymt/grids/grid_type.py
+++ b/pymt/grids/grid_type.py
@@ -1,4 +1,4 @@
-class GridType(object):
+class GridType:
     _type = None
 
     def __eq__(self, that):

--- a/pymt/grids/igrid.py
+++ b/pymt/grids/igrid.py
@@ -55,7 +55,7 @@ class NonStructuredGridError(GridTypeError):
     type = "structured"
 
 
-class IGrid(object):
+class IGrid:
     """An interface for a grid object that represents a structured or unstructured
     grid of nodes and elements.
     """

--- a/pymt/grids/map.py
+++ b/pymt/grids/map.py
@@ -62,7 +62,7 @@ class UnstructuredMap(Unstructured):
     name = "Unstructured"
 
     def __init__(self, *args, **kwargs):
-        super(UnstructuredMap, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self._point = {}
         last_offset = 0

--- a/pymt/grids/raster.py
+++ b/pymt/grids/raster.py
@@ -106,7 +106,7 @@ class UniformRectilinearPoints(RectilinearPoints):
         self._spacing = np.array(spacing, dtype=np.float64)
         self._origin = np.array(origin, dtype=np.float64)
 
-        super(UniformRectilinearPoints, self).__init__(*xi, **kwds)
+        super().__init__(*xi, **kwds)
 
     def get_spacing(self):
         """Spacing between nodes in each direction"""
@@ -140,7 +140,7 @@ class UniformRectilinear(UniformRectilinearPoints, Rectilinear):
 
     def __init__(self, shape, spacing, origin, **kwds):
         kwds["set_connectivity"] = False
-        super(UniformRectilinear, self).__init__(shape, spacing, origin, **kwds)
+        super().__init__(shape, spacing, origin, **kwds)
 
 
 if __name__ == "__main__":

--- a/pymt/grids/rectilinear.py
+++ b/pymt/grids/rectilinear.py
@@ -145,7 +145,7 @@ class RectilinearPoints(StructuredPoints):
             pass
 
         args = XI + [shape]
-        super(RectilinearPoints, self).__init__(*args, **kwds)
+        super().__init__(*args, **kwds)
 
     def get_x_coordinates(self):
         """
@@ -235,7 +235,7 @@ class Rectilinear(RectilinearPoints, Structured):
 
     def __init__(self, *args, **kwds):
         kwds["set_connectivity"] = True
-        super(Rectilinear, self).__init__(*args, **kwds)
+        super().__init__(*args, **kwds)
 
 
 if __name__ == "__main__":

--- a/pymt/grids/structured.py
+++ b/pymt/grids/structured.py
@@ -145,7 +145,7 @@ class StructuredPoints(UnstructuredPoints):
         kwds["units"] = coordinate_units
         kwds["coordinate_names"] = coordinate_names
 
-        super(StructuredPoints, self).__init__(*coordinates, **kwds)
+        super().__init__(*coordinates, **kwds)
 
     def get_shape(self, remove_singleton=False):
         """The shape of the structured grid with the given indexing.
@@ -159,16 +159,16 @@ class StructuredPoints(UnstructuredPoints):
         return shape
 
     def get_coordinate_units(self, i):
-        return super(StructuredPoints, self).get_coordinate_units(i)
+        return super().get_coordinate_units(i)
 
     def get_coordinate_name(self, i):
-        return super(StructuredPoints, self).get_coordinate_name(i)
+        return super().get_coordinate_name(i)
 
     def get_coordinate(self, i):
-        return super(StructuredPoints, self).get_coordinate(i)
+        return super().get_coordinate(i)
 
     def get_point_coordinates(self, *args, **kwds):
-        return super(StructuredPoints, self).get_point_coordinates(*args, **kwds)
+        return super().get_point_coordinates(*args, **kwds)
 
 
 class Structured(StructuredPoints, Unstructured):
@@ -205,7 +205,7 @@ class Structured(StructuredPoints, Unstructured):
             self._set_connectivity(c, o)
             kwds["set_connectivity"] = False
 
-        super(Structured, self).__init__(*args, **kwds)
+        super().__init__(*args, **kwds)
 
 
 if __name__ == "__main__":

--- a/pymt/grids/unstructured.py
+++ b/pymt/grids/unstructured.py
@@ -41,7 +41,7 @@ class UnstructuredPoints(IGrid):
             self._offset = self._connectivity + 1
             self._cell_count = 0
 
-        super(UnstructuredPoints, self).__init__()
+        super().__init__()
 
     def get_attrs(self):
         return self._attrs
@@ -268,7 +268,7 @@ class Unstructured(UnstructuredPoints):
             self._set_connectivity(connectivity, offset)
 
         kwds["set_connectivity"] = False
-        super(Unstructured, self).__init__(*args, **kwds)
+        super().__init__(*args, **kwds)
 
     def _set_connectivity(self, connectivity, offset):
         self._connectivity = np.array(connectivity, dtype=int)

--- a/pymt/mappers/imapper.py
+++ b/pymt/mappers/imapper.py
@@ -29,7 +29,7 @@ class NoMapperError(MapperError):
         return "No mapper to map %s to %s" % (self._src, self._dst)
 
 
-class IGridMapper(object):
+class IGridMapper:
     """Interface for a grid mapper."""
 
     def initialize(self, dest_grid, src_grid, **kwds):

--- a/pymt/portprinter/port_printer.py
+++ b/pymt/portprinter/port_printer.py
@@ -16,7 +16,7 @@ from .utils import (
 )
 
 
-class PortPrinter(object):
+class PortPrinter:
     _format = ""
     _printer_class = None
 

--- a/pymt/printers/nc/database.py
+++ b/pymt/printers/nc/database.py
@@ -6,7 +6,7 @@ from .ugrid import close as ugrid_close
 from .write import field_tofile
 
 
-class IDatabase(object):
+class IDatabase:
     def __init__(self):
         pass
 

--- a/pymt/printers/nc/ugrid.py
+++ b/pymt/printers/nc/ugrid.py
@@ -21,7 +21,7 @@ def close(path):
         del _OPENED_FILES[path]
 
 
-class NetcdfField(object):
+class NetcdfField:
     def __init__(
         self, path, field, fmt="NETCDF4", append=False, time=None, keep_open=False
     ):

--- a/pymt/printers/nc/ugrid_read.py
+++ b/pymt/printers/nc/ugrid_read.py
@@ -6,7 +6,7 @@ from ...grids import utils as gutils
 from .constants import open_netcdf
 
 
-class NetcdfFieldReader(object):
+class NetcdfFieldReader:
     def __init__(self, path, fmt="NETCDF4"):
         self._path = path
 

--- a/pymt/services/constant/constant.py
+++ b/pymt/services/constant/constant.py
@@ -3,7 +3,7 @@ import numpy as np
 import yaml
 
 
-class ConstantScalars(object):
+class ConstantScalars:
     """Service component that returns scalars."""
 
     def initialize(self, filename):

--- a/pymt/services/gridreader/gridreader.py
+++ b/pymt/services/gridreader/gridreader.py
@@ -8,7 +8,7 @@ from .interpolate import create_interpolators
 from .time_series_names import get_time_series_names
 
 
-class TimeInterpolator(object):
+class TimeInterpolator:
     def __init__(self):
         self._shape = ()
         self._spacing = ()

--- a/pymt/testing/ports.py
+++ b/pymt/testing/ports.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-class UniformRectilinearGridPort(object):
+class UniformRectilinearGridPort:
     def __init__(self):
         self._shape = (4, 5)
         self._spacing = (1.0, 2.0)

--- a/pymt/testing/services.py
+++ b/pymt/testing/services.py
@@ -22,7 +22,7 @@ def get_class_names():
     return _CLASSES.keys()
 
 
-# class EmptyPort(object):
+# class EmptyPort:
 class EmptyPort(UniformRectilinearPoints):
     _name = None
 

--- a/pymt/timeline.py
+++ b/pymt/timeline.py
@@ -70,7 +70,7 @@ one-timer
 import bisect
 
 
-class Timeline(object):
+class Timeline:
     """Create a timeline of events.
 
     Parameters

--- a/tests/component/test_grid_mixin.py
+++ b/tests/component/test_grid_mixin.py
@@ -5,7 +5,7 @@ from pytest import approx
 from pymt.component.grid import GridMixIn
 
 
-class Port(object):
+class Port:
     def __init__(self, name, uses=None, provides=None):
         self._name = name
         self._uses = uses or []
@@ -31,7 +31,7 @@ def test_exchange_items():
     class Component(GridMixIn):
         def __init__(self):
             self._port = Port("test", uses=["invar"], provides=["outvar"])
-            super(Component, self).__init__()
+            super().__init__()
 
     c = Component()
     assert c.input_items == ["invar"]
@@ -42,7 +42,7 @@ def test_no_exchange_items():
     class Component(GridMixIn):
         def __init__(self):
             self._port = Port("test")
-            super(Component, self).__init__()
+            super().__init__()
 
     c = Component()
     assert c.input_items == []
@@ -63,7 +63,7 @@ def test_raster_1d():
     class Component(GridMixIn):
         def __init__(self):
             self._port = RasterPort("test", uses=["invar"])
-            super(Component, self).__init__()
+            super().__init__()
 
     c = Component()
     assert c.get_x("invar") == approx(np.array([3.0, 5.0, 7.0]))
@@ -83,7 +83,7 @@ def test_raster_2d():
     class Component(GridMixIn):
         def __init__(self):
             self._port = RasterPort("test-2d", uses=["invar"], provides=["outvar"])
-            super(Component, self).__init__()
+            super().__init__()
 
     c = Component()
     assert c.name == "test-2d"
@@ -108,7 +108,7 @@ def test_raster_3d():
     class Component(GridMixIn):
         def __init__(self):
             self._port = RasterPort("test-3d", uses=["invar"])
-            super(Component, self).__init__()
+            super().__init__()
 
     c = Component()
     assert c.get_x(0) == approx(
@@ -142,7 +142,7 @@ def test_rectilinear():
     class Component(GridMixIn):
         def __init__(self):
             self._port = RectilinearPort("test", uses=["invar"])
-            super(Component, self).__init__()
+            super().__init__()
 
     c = Component()
     assert c.get_grid_type(0) == "RECTILINEAR"
@@ -164,7 +164,7 @@ def test_structured():
     class Component(GridMixIn):
         def __init__(self):
             self._port = StructuredPort("test", uses=["invar"])
-            super(Component, self).__init__()
+            super().__init__()
 
     c = Component()
     assert c.get_grid_type(0) == "STRUCTURED"
@@ -189,7 +189,7 @@ def test_unstructured():
     class Component(GridMixIn):
         def __init__(self):
             self._port = UnstructuredPort("test", uses=["invar"])
-            super(Component, self).__init__()
+            super().__init__()
 
     c = Component()
     assert c.get_grid_type(0) == "UNSTRUCTURED"
@@ -208,7 +208,7 @@ def test_get_grid_shape_is_none():
     class Component(GridMixIn):
         def __init__(self):
             self._port = UnstructuredPort("test", uses=["invar"])
-            super(Component, self).__init__()
+            super().__init__()
 
     c = Component()
     assert c.get_grid_type(0) == "UNSTRUCTURED"
@@ -225,7 +225,7 @@ def test_get_grid_shape_raises():
     class Component(GridMixIn):
         def __init__(self):
             self._port = UnstructuredPort("test", uses=["invar"])
-            super(Component, self).__init__()
+            super().__init__()
 
     c = Component()
     assert c.get_grid_type(0) == "UNSTRUCTURED"
@@ -248,7 +248,7 @@ def test_structured_1d():
     class Component(GridMixIn):
         def __init__(self):
             self._port = RectilinearPort("test", uses=["invar"])
-            super(Component, self).__init__()
+            super().__init__()
 
     c = Component()
     assert c.get_grid_type(0) == "RECTILINEAR"

--- a/tests/grids/test_utils.py
+++ b/tests/grids/test_utils.py
@@ -7,7 +7,7 @@ import pymt.grids.utils as utils
 from pymt.grids import Structured, UniformRectilinear, UnstructuredPoints
 
 
-class NumpyArrayMixIn(object):
+class NumpyArrayMixIn:
     def assertArrayEqual(self, actual, expected):
         try:
             assert_array_equal(actual, expected)


### PR DESCRIPTION
This PR simplifies how classes are used since Python 3, and removes unnecessary coding styles that were required for Python 2 compatibility.
* Classes does not need to inherit from `object`
* Simpler use with `super()`; see [PEP 3135](https://www.python.org/dev/peps/pep-3135/)