### PR TITLE
fix: numpy aliases of builtin types is deprecated

### DIFF
--- a/pymt/grids/structured.py
+++ b/pymt/grids/structured.py
@@ -140,7 +140,7 @@ class StructuredPoints(UnstructuredPoints):
             "units", get_default_coordinate_units(len(coordinates))
         )
 
-        self._shape = np.array(shape, dtype=np.int)
+        self._shape = np.array(shape, dtype=int)
 
         kwds["units"] = coordinate_units
         kwds["coordinate_names"] = coordinate_names

--- a/pymt/grids/unstructured.py
+++ b/pymt/grids/unstructured.py
@@ -165,7 +165,7 @@ class UnstructuredPoints(IGrid):
         nodes_per_cell = np.diff(self._offset)
 
         max_vertices = max(self._offset[0], nodes_per_cell.max())
-        matrix = np.empty((self._cell_count, max_vertices), dtype=np.int)
+        matrix = np.empty((self._cell_count, max_vertices), dtype=int)
 
         offset = self._offset[0]
         matrix[0, :offset] = self._connectivity[:offset]

--- a/pymt/grids/utils.py
+++ b/pymt/grids/utils.py
@@ -38,7 +38,7 @@ def coordinates_to_numpy_matrix(*args):
     args = args_as_numpy_arrays(*args)
     assert_arrays_are_equal_size(*args)
 
-    coords = np.empty((len(args), len(args[0])), dtype=np.float)
+    coords = np.empty((len(args), len(args[0])), dtype=float)
     for (dim, arg) in enumerate(args):
         coords[dim][:] = arg.flatten()
     return coords
@@ -94,7 +94,7 @@ def _find_first(array, value):
 
 
 def connectivity_matrix_as_array(face_nodes, bad_val):
-    nodes_per_face = np.empty(face_nodes.shape[0], dtype=np.int)
+    nodes_per_face = np.empty(face_nodes.shape[0], dtype=int)
     for (face_id, face) in enumerate(face_nodes):
         nnodes = _find_first(face, bad_val)
         if nnodes > 0:

--- a/pymt/mappers/celltopoint.py
+++ b/pymt/mappers/celltopoint.py
@@ -12,7 +12,7 @@ from .imapper import IGridMapper, IncompatibleGridError
 def map_points_to_cells(coords, src_grid, src_point_ids, bad_val=-1):
     (dst_x, dst_y) = coords
 
-    point_to_cell_id = np.empty(len(dst_x), dtype=np.int)
+    point_to_cell_id = np.empty(len(dst_x), dtype=int)
     point_to_cell_id.fill(bad_val)
 
     for (j, point_id) in enumerate(src_point_ids):

--- a/pymt/mappers/pointtocell.py
+++ b/pymt/mappers/pointtocell.py
@@ -52,7 +52,7 @@ class PointToCell(IGridMapper):
             raise ValueError("size mismatch between source and point count")
 
         if dst_vals is None:
-            dst_vals = np.array([bad_val] * self._dst_cell_count, dtype=np.float)
+            dst_vals = np.array([bad_val] * self._dst_cell_count, dtype=float)
         if dst_vals.size != self._dst_cell_count:
             raise ValueError("size mismatch between destination and cell count")
 

--- a/pymt/services/constant/constant.py
+++ b/pymt/services/constant/constant.py
@@ -19,7 +19,7 @@ class ConstantScalars(object):
 
         self._vars = {}
         for (name, value) in scalar_vars.items():
-            self._vars[name] = np.array(value, dtype=np.float)
+            self._vars[name] = np.array(value, dtype=float)
 
         self._shape = (1,)
         self._spacing = (1.0,)

--- a/tests/mappers/test_mapper.py
+++ b/tests/mappers/test_mapper.py
@@ -28,7 +28,7 @@ def test_cell_to_point():
     src = UniformRectilinear((2, 4), (2, 1), (0, 0))
     dst = UnstructuredPoints(dst_x, dst_y)
 
-    src_vals = np.arange(src.get_cell_count(), dtype=np.float)
+    src_vals = np.arange(src.get_cell_count(), dtype=float)
 
     mapper = CellToPoint()
     mapper.initialize(dst, src)
@@ -36,7 +36,7 @@ def test_cell_to_point():
 
     assert_array_equal(dst_vals, [0.0, 2.0, -999.0])
 
-    src_vals = np.arange(src.get_cell_count(), dtype=np.float)
+    src_vals = np.arange(src.get_cell_count(), dtype=float)
     src_vals[0] = -9999
     dst_vals = np.zeros(dst.get_point_count()) + 100
     mapper.run(src_vals, dst_vals=dst_vals)
@@ -53,7 +53,7 @@ def test_point_to_cell():
     src = UnstructuredPoints(src_x, src_y)
     dst = UniformRectilinear((2, 4), (2, 1), (0, 0))
 
-    src_vals = np.arange(src.get_point_count(), dtype=np.float)
+    src_vals = np.arange(src.get_point_count(), dtype=float)
 
     mapper = PointToCell()
     mapper.initialize(dst, src)
@@ -81,7 +81,7 @@ def test_point_to_cell_on_edges():
     mapper = PointToCell()
     mapper.initialize(dst, src)
 
-    src_vals = np.arange(src.get_point_count(), dtype=np.float)
+    src_vals = np.arange(src.get_point_count(), dtype=float)
     dst_vals = np.zeros(dst.get_cell_count()) - 1
     mapper.run(src_vals, dst_vals=dst_vals)
     assert_array_equal(dst_vals, [1.0, 0.5, 3.0])
@@ -96,7 +96,7 @@ def test_point_to_cell_big():
     mapper = PointToCell()
     mapper.initialize(dst, src)
 
-    src_vals = np.arange(src.get_point_count(), dtype=np.float)
-    dst_vals = np.zeros(dst.get_cell_count(), dtype=np.float) - 1
+    src_vals = np.arange(src.get_point_count(), dtype=float)
+    dst_vals = np.zeros(dst.get_cell_count(), dtype=float) - 1
     mapper.run(src_vals, dst_vals=dst_vals)
     assert_array_equal(dst_vals, src_vals)


### PR DESCRIPTION
This fixes a deprecation from [numpy 1.20.0](https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated).