### PR TITLE
Fix missing netcdf engine error on Windows

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,3 +1,4 @@
+h5netcdf
 pytest
 pytest-benchmark
 pytest-cov

--- a/tests/portprinter/test_port_printer_queue.py
+++ b/tests/portprinter/test_port_printer_queue.py
@@ -47,11 +47,11 @@ port=earth_port
                 printer.write()
 
         assert os.path.isfile("air__density.nc")
-        ds = xarray.open_dataset("air__density.nc")
+        ds = xarray.open_dataset("air__density.nc", engine="h5netcdf")
         assert "air__density" in ds.variables
         assert ds.dims["time"] == 5
 
         assert os.path.isfile("glacier_top_surface__slope.nc")
-        ds = xarray.open_dataset("glacier_top_surface__slope.nc")
+        ds = xarray.open_dataset("glacier_top_surface__slope.nc", engine="h5netcdf")
         assert "glacier_top_surface__slope" in ds.variables
         assert ds.dims["time"] == 5

--- a/tests/printers/nc/test_nc.py
+++ b/tests/printers/nc/test_nc.py
@@ -33,7 +33,7 @@ def test_raster(tmpdir, ndims):
 
         assert os.path.isfile("raster.nc")
 
-        ds = xarray.open_dataset("raster.nc")
+        ds = xarray.open_dataset("raster.nc", engine="h5netcdf")
 
         assert {"mesh", "Elevation", "time"}.issubset(ds.variables)
         assert "time" in ds.dims


### PR DESCRIPTION
This pull request fixes an error we began seeing with, I think, newer versions of *xarray* when running the netcdf printer tests. The error was only on Windows and indicated that *xarray* *"did not find a match in any of xarray's currently installed IO backends"*. For whatever reason, *h5netcdf* is not installed on Windows but that is the backend engine needed to read some of the test netcdf files. 

I've added *h5netcdf* as an explicit requirement in *requirements-testing.txt* and explicitly set the *engine* to *h5netcdf* when calling `xr.open_dataset`.    