### PR TITLE
Drop file: URI from pip install

### DIFF
--- a/environment-docs.yml
+++ b/environment-docs.yml
@@ -5,5 +5,5 @@ dependencies:
   - gimli.units
   - pip
   - pip:
-    - -r file:requirements.txt
-    - -r file:requirements-docs.txt
+    - -r requirements.txt
+    - -r requirements-docs.txt


### PR DESCRIPTION
This PR includes a minor change: as described [here](https://stackoverflow.com/a/59056234) and [here](https://stackoverflow.com/a/68586065), valid syntax for the `file:` URI has changed in `pip`, and the current form raises an exception. Removed the `file:` URI from the environment file.