### PR TITLE
Update the environment.yml file for use with Binder

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,12 +2,16 @@ name: test-environment
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
-  - pymt=1.0.3
-  - pymt_gipl
-  - pymt_ecsimplesnow
+  - python=3.9
+  - pymt
   - seaborn
   - matplotlib
   - pandas
   - numpy
-
+  - pymt_cem
+  - pymt_child
+  - pymt_ecsimplesnow
+  - pymt_gipl
+  - pymt_hydrotrend
+  - pymt_permamodel
+  - pymt_sedflux


### PR DESCRIPTION
As reported by @iovereem, some of the notebooks are not running on Binder. I've updated the *environment.yml* file to include additional dependencies and removed the *pymt* version requirement. 