### PR TITLE
Reformat for new version of *black*

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
 
   lint:
+    name: Check code format
     # We want to run on external PRs, but not on our own internal PRs as they'll be run
     # by the push to the branch. Without this if check, checks are duplicated since
     # internal PRs match both the push and pull_request events.
@@ -18,4 +19,5 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: psf/black@stable
         with:
-          args: ". --check"
+          options: "--check --verbose --diff"
+          src: "setup.py pymt tests"

--- a/pymt/framework/bmi_docstring.py
+++ b/pymt/framework/bmi_docstring.py
@@ -6,7 +6,7 @@ from model_metadata import MetadataNotFoundError, ModelMetadata
 
 
 # {{ desc|trim|wordwrap(70) if desc }}
-_DOCSTRING = u"""
+_DOCSTRING = """
 Basic Model Interface for {{ name }}.
 
 {{ desc|trim if desc }}

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(filename):
         return fp.read()
 
 
-long_description = u"\n\n".join(
+long_description = "\n\n".join(
     [
         read("README.rst"),
         read("AUTHORS.rst"),

--- a/tests/framework/test_bmi_docstring.py
+++ b/tests/framework/test_bmi_docstring.py
@@ -1,6 +1,6 @@
 from pymt.framework.bmi_docstring import bmi_docstring
 
-DOCSTRING = u"""Basic Model Interface for Model.
+DOCSTRING = """Basic Model Interface for Model.
 
 
 

--- a/tests/grids/test_esmp.py
+++ b/tests/grids/test_esmp.py
@@ -231,7 +231,7 @@ def test_values_on_cells():
 
     (x, y) = np.meshgrid(np.arange(0.5, 299.5, 1.0), np.arange(0.5, 299.5, 1.0))
 
-    data = np.sin(np.sqrt(x ** 2 + y ** 2) * np.pi / n_rows)
+    data = np.sin(np.sqrt(x**2 + y**2) * np.pi / n_rows)
     src.add_field("srcfield", data, centering="zonal")
 
     dst = EsmpRasterField((n_rows * 2 - 1, n_cols * 2 - 1), (1.0 / 2, 1.0 / 2), (0, 0))
@@ -245,7 +245,7 @@ def test_values_on_cells():
     assert f is dst_field
 
     (x, y) = np.meshgrid(np.arange(0.5, 299.5, 0.5), np.arange(0.5, 299.5, 0.5))
-    exact = np.sin(np.sqrt(x ** 2 + y ** 2) * np.pi / n_rows)
+    exact = np.sin(np.sqrt(x**2 + y**2) * np.pi / n_rows)
     residual = np.abs(exact.flat - f.data) / (n_rows * n_cols * 4.0)
     assert residual == approx(0.0, abs=1e-7)
 
@@ -255,7 +255,7 @@ def test_values_on_points():
     src = EsmpRasterField((n_rows, n_cols), (1, 1), (0, 0))
 
     (x, y) = np.meshgrid(np.arange(0.5, 300.5, 1.0), np.arange(0.5, 300.5, 1.0))
-    data = np.sin(np.sqrt(x ** 2 + y ** 2) * np.pi / n_rows)
+    data = np.sin(np.sqrt(x**2 + y**2) * np.pi / n_rows)
     src.add_field("srcfield_at_points", data, centering="point")
 
     dst = EsmpRasterField((n_rows * 2 - 1, n_cols * 2 - 1), (1.0 / 2, 1.0 / 2), (0, 0))
@@ -268,6 +268,6 @@ def test_values_on_points():
     f = run_regridding(src_field, dst_field, method=esmf.RegridMethod.BILINEAR)
 
     (x, y) = np.meshgrid(np.arange(0.5, 300.0, 0.5), np.arange(0.5, 300.0, 0.5))
-    exact = np.sin(np.sqrt(x ** 2 + y ** 2) * np.pi / n_rows)
+    exact = np.sin(np.sqrt(x**2 + y**2) * np.pi / n_rows)
     residual = np.abs(exact.flat - f.data) / (n_rows * n_cols * 4.0)
     assert residual == approx(0.0, abs=1e-7)

--- a/tests/printers/nc/test_nc_examples.py
+++ b/tests/printers/nc/test_nc_examples.py
@@ -12,11 +12,11 @@ def sample_surface(x, y, alpha, eta=1.0, purity=1.0):
         1.0
         + eta
         * (
-            np.exp(-(x ** 2) - (y - alpha) ** 2)
-            + np.exp(-(x ** 2) - (y + alpha) ** 2)
-            + 2 * purity * np.exp(-(x ** 2) - y ** 2) * np.cos(2 * alpha * x)
+            np.exp(-(x**2) - (y - alpha) ** 2)
+            + np.exp(-(x**2) - (y + alpha) ** 2)
+            + 2 * purity * np.exp(-(x**2) - y**2) * np.cos(2 * alpha * x)
         )
-        / (2 * (1 + np.exp(-(alpha ** 2))))
+        / (2 * (1 + np.exp(-(alpha**2))))
     ) / 2.0
 
 


### PR DESCRIPTION
This pull request reformats Python code to conform to the newest version of *black*. The main difference is in the hugging of the `**` operator.