### PR TITLE
Upgrade to Python 3.8 syntax

### DIFF
--- a/news/159.misc
+++ b/news/159.misc
@@ -1,0 +1,3 @@
+Removed dependency on ``six`` since we don't support Python 2 and updated code
+to use Python 3.8+ syntax.
+

--- a/notebooks/cem.ipynb
+++ b/notebooks/cem.ipynb
@@ -275,7 +275,7 @@
     "cem.get_grid_spacing(grid_id, out=spacing)\n",
     "\n",
     "print('The grid has %d rows and %d columns' % (shape[0], shape[1]))\n",
-    "print('The spacing between rows is %f m and between columns is %f m' % (spacing[0], spacing[1]))"
+    "print('The spacing between rows is {:f} m and between columns is {:f} m'.format(spacing[0], spacing[1]))"
    ]
   },
   {
@@ -399,7 +399,7 @@
     "# read in the csv file of bedload measurements in the Rhine River, the Netherlands\n",
     "# these data were collected over different days over a season in 2004, at nearby locations.\n",
     "# plot how river discharge controls bedload; Q (x-axis) and Qb (y-axis) data. \n",
-    "# label both axes\n"
+    "# label both axes"
    ]
   },
   {
@@ -425,7 +425,7 @@
    "outputs": [],
    "source": [
     "# extrapolate this relationship and calculate how much river discharge, Q, \n",
-    "# would be needed to transport the model specification Qb of 1250 kg/s\n"
+    "# would be needed to transport the model specification Qb of 1250 kg/s"
    ]
   },
   {

--- a/notebooks/child.ipynb
+++ b/notebooks/child.ipynb
@@ -23,8 +23,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function\n",
-    "\n",
     "# Some magic to make plots appear within the notebook\n",
     "%matplotlib inline\n",
     "\n",

--- a/notebooks/hydrotrend.ipynb
+++ b/notebooks/hydrotrend.ipynb
@@ -60,7 +60,7 @@
    "source": [
     "# To start, import numpy and matplotlib.\n",
     "import matplotlib.pyplot as plt\n",
-    "import numpy as np\n"
+    "import numpy as np"
    ]
   },
   {
@@ -237,8 +237,7 @@
     "# compare with the last year\n",
     "plt.plot(q[-366:-1],'grey')\n",
     "plt.title('HydroTrend simulation of first and last year discharge, Waiapaoa River')\n",
-    "plt.show()\n",
-    "\n"
+    "plt.show()"
    ]
   },
   {
@@ -269,7 +268,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# your code goes here\n"
+    "# your code goes here"
    ]
   },
   {
@@ -288,7 +287,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# here you can calculate the maximum river discharge.\n"
+    "# here you can calculate the maximum river discharge."
    ]
   },
   {
@@ -337,7 +336,7 @@
     "# your code goes here\n",
     "# you will have to sum all days of the individual years, to get the annual loads, then calculate the mean over the 100 years.\n",
     "# one possible trick is to use the .reshape() method\n",
-    "# plot a graph of the 100 years timeseries of the total annual loads \n"
+    "# plot a graph of the 100 years timeseries of the total annual loads "
    ]
   },
   {
@@ -346,7 +345,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# take the mean over the 100 years\n"
+    "# take the mean over the 100 years"
    ]
   },
   {
@@ -430,8 +429,7 @@
     "# your code that prints out the mean river discharge, the mean sediment load and the mean bedload goes here\n",
     "\n",
     "\n",
-    "# print out these same parameters for the basecase for comparison\n",
-    "\n"
+    "# print out these same parameters for the basecase for comparison"
    ]
   },
   {

--- a/notebooks/hydrotrend_Ganges.ipynb
+++ b/notebooks/hydrotrend_Ganges.ipynb
@@ -306,7 +306,7 @@
     "z = np.polyfit(q_y_vals.flatten(), q_mean_rows_GQ0.flatten(), 1)\n",
     "p = np.poly1d(z)\n",
     "plt.plot(q_y_vals, p(q_y_vals), \"r--\")\n",
-    "plt.suptitle(\"y=%.6fx+%.6f\" % (z[0], z[1]), y=0.8)\n",
+    "plt.suptitle(\"y={:.6f}x+{:.6f}\".format(z[0], z[1]), y=0.8)\n",
     "plt.show()"
    ]
   },
@@ -359,7 +359,7 @@
     "z = np.polyfit(qs_y_vals.flatten(), qs_mean_rows_GQ0.flatten(), 1)\n",
     "p = np.poly1d(z)\n",
     "plt.plot(qs_y_vals, p(qs_y_vals), \"r--\")\n",
-    "plt.suptitle(\"y=%.6fx+%.6f\" % (z[0], z[1]), y=0.85)\n",
+    "plt.suptitle(\"y={:.6f}x+{:.6f}\".format(z[0], z[1]), y=0.85)\n",
     "plt.show()"
    ]
   },
@@ -394,13 +394,13 @@
    "outputs": [],
    "source": [
     "print(\n",
-    "    \"Mean Water Discharge = {0} {1}\".format(\n",
+    "    \"Mean Water Discharge = {} {}\".format(\n",
     "        q_GQ0.mean(),\n",
     "        hydrotrend_GQ0.get_var_units(\"channel_exit_water__volume_flow_rate\"),\n",
     "    )\n",
     ")\n",
     "print(\n",
-    "    \"Mean Bedload Discharge = {0} {1}\".format(\n",
+    "    \"Mean Bedload Discharge = {} {}\".format(\n",
     "        qb_GQ0.mean(),\n",
     "        hydrotrend_GQ0.get_var_units(\n",
     "            \"channel_exit_water_sediment~bedload__mass_flow_rate\"\n",
@@ -408,7 +408,7 @@
     "    )\n",
     ")\n",
     "print(\n",
-    "    \"Mean Suspended Sediment Discharge = {0} {1}\".format(\n",
+    "    \"Mean Suspended Sediment Discharge = {} {}\".format(\n",
     "        qs_GQ0.mean(),\n",
     "        hydrotrend_GQ0.get_var_units(\n",
     "            \"channel_exit_water_sediment~suspended__mass_flow_rate\"\n",
@@ -416,7 +416,7 @@
     "    )\n",
     ")\n",
     "print(\n",
-    "    \"Mean Suspended Sediment Concentration = {0} {1}\".format(\n",
+    "    \"Mean Suspended Sediment Concentration = {} {}\".format(\n",
     "        cs_GQ0.mean(),\n",
     "        hydrotrend_GQ0.get_var_units(\n",
     "            \"channel_exit_water_sediment~suspended__mass_concentration\"\n",

--- a/notebooks/sedflux3d.ipynb
+++ b/notebooks/sedflux3d.ipynb
@@ -23,8 +23,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function\n",
-    "\n",
     "# Some magic to make plots appear within the notebook\n",
     "%matplotlib inline\n",
     "\n",

--- a/notebooks/subside.ipynb
+++ b/notebooks/subside.ipynb
@@ -43,8 +43,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function\n",
-    "\n",
     "%matplotlib inline\n",
     "\n",
     "import matplotlib.pyplot as plt"

--- a/pymt/cmd/cmt_config.py
+++ b/pymt/cmd/cmt_config.py
@@ -3,7 +3,6 @@ import os
 import socket
 import sys
 
-import six
 import yaml
 from model_metadata.find import find_model_data_files
 
@@ -17,19 +16,19 @@ class redirect:
         self._err = stderr or sys.stderr
 
     def __enter__(self):
-        if isinstance(self._out, six.string_types):
+        if isinstance(self._out, str):
             sys.stdout = open(self._out, "w")
         else:
             sys.stdout = self._out
-        if isinstance(self._err, six.string_types):
+        if isinstance(self._err, str):
             sys.stderr = open(self._err, "w")
         else:
             sys.stderr = self._err
 
     def __exit__(self, type_, value, traceback):
-        if isinstance(self._out, six.string_types):
+        if isinstance(self._out, str):
             sys.stdout.close()
-        if isinstance(self._err, six.string_types):
+        if isinstance(self._err, str):
             sys.stderr.close()
 
         sys.stdout = self._stdout

--- a/pymt/component/component.py
+++ b/pymt/component/component.py
@@ -57,7 +57,6 @@ ValueError: AirPort
 """
 import warnings
 
-import six
 import yaml
 
 from ..events.chain import ChainEvent
@@ -146,7 +145,7 @@ class Component(GridMixIn):
         if provides is None:
             provides = set()
 
-        if isinstance(port, six.string_types):
+        if isinstance(port, str):
             if name is None:
                 name = port
             self._port = services.instantiate_component(port, name)
@@ -419,7 +418,7 @@ class Component(GridMixIn):
         Component
             A newly-created component.
         """
-        with open(path, "r") as yaml_file:
+        with open(path) as yaml_file:
             return cls._from_yaml(yaml_file.read())
 
     @classmethod

--- a/pymt/component/model.py
+++ b/pymt/component/model.py
@@ -1,6 +1,5 @@
 import os
 
-import six
 import yaml
 
 from .component import Component
@@ -30,7 +29,7 @@ def get_exchange_item_mapping(items):
     """
     mapping = []
     for item in items:
-        if isinstance(item, six.string_types):
+        if isinstance(item, str):
             item_map = (item, item)
         else:
             try:
@@ -83,7 +82,7 @@ class Model:
     def go(self, filename=None):
         """Start the model."""
         if filename:
-            with open(filename, "r") as f:
+            with open(filename) as f:
                 model = yaml.safe_load(f.read())
             self._driver, self._duration = (model["driver"], model["duration"])
 
@@ -158,7 +157,7 @@ class Model:
         model : Model
             A newly-created model.
         """
-        with open(filename, "r") as fp:
+        with open(filename) as fp:
             return cls.load(fp)
 
     @classmethod

--- a/pymt/errors.py
+++ b/pymt/errors.py
@@ -22,7 +22,7 @@ class BadUnitError(PymtError):
         self._unit = unit
 
     def __str__(self):
-        return "unknown unit ({0!r})".format(self._unit)
+        return f"unknown unit ({self._unit!r})"
 
 
 class IncompatibleUnitsError(PymtError):
@@ -31,4 +31,4 @@ class IncompatibleUnitsError(PymtError):
         self._dst = dst
 
     def __str__(self):
-        return "incompatible units ({0!r}, {1!r})".format(self._src, self._dst)
+        return f"incompatible units ({self._src!r}, {self._dst!r})"

--- a/pymt/events/manager.py
+++ b/pymt/events/manager.py
@@ -45,8 +45,8 @@ hello!
 hello!
 hello from finalize
 """
-from six import StringIO
-from six.moves.configparser import ConfigParser
+from configparser import ConfigParser
+from io import StringIO
 
 from ..timeline import Timeline
 from ..utils.prefix import names_with_prefix

--- a/pymt/events/port.py
+++ b/pymt/events/port.py
@@ -3,7 +3,6 @@
 import os
 import sys
 
-import six
 import yaml
 
 from ..component.grid import GridMixIn
@@ -26,7 +25,7 @@ class PortEvent(GridMixIn):
     """
 
     def __init__(self, *args, **kwds):
-        if isinstance(kwds["port"], six.string_types):
+        if isinstance(kwds["port"], str):
             self._port = services.get_component_instance(kwds["port"])
         else:
             self._port = kwds["port"]
@@ -34,7 +33,7 @@ class PortEvent(GridMixIn):
         self._init_args = kwds.get("init_args", [])
         self._run_dir = kwds.get("run_dir", ".")
 
-        if isinstance(self._init_args, six.string_types):
+        if isinstance(self._init_args, str):
             self._init_args = [self._init_args]
 
         self._status_fp = open(
@@ -114,11 +113,11 @@ class PortMapEvent:
     """
 
     def __init__(self, *args, **kwds):
-        if isinstance(kwds["src_port"], six.string_types):
+        if isinstance(kwds["src_port"], str):
             self._src = services.get_component_instance(kwds["src_port"])
         else:
             self._src = kwds["src_port"]
-        if isinstance(kwds["dst_port"], six.string_types):
+        if isinstance(kwds["dst_port"], str):
             self._dst = services.get_component_instance(kwds["dst_port"])
         else:
             self._dst = kwds["dst_port"]

--- a/pymt/framework/bmi_bridge.py
+++ b/pymt/framework/bmi_bridge.py
@@ -344,7 +344,7 @@ class _BmiCap(DeprecatedMethods):
             # grid = self.var_grid(name)
             dtype = self.var_type(name)
             if dtype == "":
-                raise ValueError("{name} not understood".format(name=name))
+                raise ValueError(f"{name} not understood")
             n_items = self.var_nbytes(name) // self.var_itemsize(name)
             # loc = self.var_grid_loc(name)
             out = np.empty(n_items, dtype=dtype)
@@ -781,10 +781,10 @@ def bmi_factory(cls):
         _cls = cls
 
         def __str__(self):
-            return "{0}".format(cls.__name__)
+            return f"{cls.__name__}"
 
         def __repr__(self):
-            return "<{0}()>".format(cls.__name__)
+            return f"<{cls.__name__}()>"
 
     BmiWrapper.__name__ = cls.__name__
     return BmiWrapper

--- a/pymt/framework/bmi_docstring.py
+++ b/pymt/framework/bmi_docstring.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python
 import jinja2
-import six
 from landlab.core.messages import format_message
 from model_metadata import MetadataNotFoundError, ModelMetadata
 
@@ -103,7 +102,7 @@ def bmi_docstring(
         meta = ModelMetadata.from_obj(plugin)
         # meta = PluginMetadata(plugin)
     except MetadataNotFoundError:
-        if isinstance(plugin, six.string_types):
+        if isinstance(plugin, str):
             info = dict(
                 authors=author,
                 version=version,
@@ -136,9 +135,9 @@ def bmi_docstring(
     cite_as = cite_as or info["cite_as"]
     parameters = parameters or defaults
 
-    if isinstance(author, six.string_types):
+    if isinstance(author, str):
         author = [author]
-    if isinstance(cite_as, six.string_types):
+    if isinstance(cite_as, str):
         cite_as = [cite_as]
 
     summary = format_message(summary)

--- a/pymt/framework/bmi_mapper.py
+++ b/pymt/framework/bmi_mapper.py
@@ -175,7 +175,7 @@ class GridMapperMixIn:
         except AttributeError:
             self._esmf_field = dict()
 
-        _id = "{gid}.{name}@{at}".format(gid=gid, name=name, at=at)
+        _id = f"{gid}.{name}@{at}"
 
         try:
             self._esmf_field[_id]

--- a/pymt/framework/bmi_plot.py
+++ b/pymt/framework/bmi_plot.py
@@ -39,7 +39,7 @@ def quick_plot(bmi, name, **kwds):
         y = np.arange(shape[-2]) * spacing[-2] + origin[-2]
         plt.pcolormesh(x, y, z.reshape(shape), **kwds)
     else:
-        raise ValueError("no plotter for {gtype}".format(gtype=gtype))
+        raise ValueError(f"no plotter for {gtype}")
 
     plt.axis("tight")
     plt.gca().set_aspect("equal")
@@ -47,4 +47,4 @@ def quick_plot(bmi, name, **kwds):
     plt.ylabel(y_label)
 
     cbar = plt.colorbar()
-    cbar.ax.set_ylabel("{name} ({units})".format(name=name, units=bmi.var_units(name)))
+    cbar.ax.set_ylabel(f"{name} ({bmi.var_units(name)})")

--- a/pymt/framework/bmi_setup.py
+++ b/pymt/framework/bmi_setup.py
@@ -98,7 +98,7 @@ class SetupMixIn:
         contact = self.author[0]
         email = self.email
         if email != "-":
-            contact = "{name} <{email}>".format(name=contact, email=email)
+            contact = f"{contact} <{email}>"
         return contact
 
     @property
@@ -154,7 +154,7 @@ def get_initialize_arg(dir_):
         Argument that can be passed to a BMI initialize method.
     """
     readme = os.path.join(dir_, "README.yaml")
-    with open(readme, "r") as fp:
+    with open(readme) as fp:
         metadata = yaml.safe_load(fp)
 
     args = metadata["bmi"]["initialize"]["args"]
@@ -178,7 +178,7 @@ def url_to_input_file_repo(name):
     str
         URL of input-file repository.
     """
-    return "https://github.com/mcflugen/{name}-input".format(name=name)
+    return f"https://github.com/mcflugen/{name}-input"
 
 
 def url_to_input_file_zip(name):
@@ -219,4 +219,4 @@ def fetch_input(name, path=None):
     with zipfile.ZipFile(path_, "r") as zipfp:
         zipfp.extractall(path=extract_to)
 
-    return os.path.join(extract_to, "{name}-input-master".format(name=name))
+    return os.path.join(extract_to, f"{name}-input-master")

--- a/pymt/framework/bmi_timeinterp.py
+++ b/pymt/framework/bmi_timeinterp.py
@@ -7,9 +7,9 @@ from .timeinterp import TimeInterpolator
 class BmiTimeInterpolator:
     def __init__(self, *args, **kwds):
         method = kwds.pop("method", "linear")
-        self._interpolators = dict(
-            [(name, None) for name in self.output_var_names if "__" in name]
-        )
+        self._interpolators = {
+            name: None for name in self.output_var_names if "__" in name
+        }
         self.reset(method=method)
 
         super().__init__(*args, **kwds)
@@ -24,7 +24,7 @@ class BmiTimeInterpolator:
                 self._interpolators[name].add_data([(self.time, self.get_value(name))])
             except BmiError:
                 self._interpolators.pop(name)
-                print("unable to get value for {name}. ignoring".format(name=name))
+                print(f"unable to get value for {name}. ignoring")
 
     def interpolate(self, name, at):
         return self._interpolators[name].interpolate(at)

--- a/pymt/framework/bmi_ugrid.py
+++ b/pymt/framework/bmi_ugrid.py
@@ -191,7 +191,7 @@ class StructuredQuadrilateral(_Base):
                 ("cf_role", "grid_topology"),
                 (
                     "long_name",
-                    "Topology data of {}D structured quadrilateral".format(self.ndim),
+                    f"Topology data of {self.ndim}D structured quadrilateral",
                 ),
                 ("topology_dimension", self.ndim),
                 ("node_coordinates", " ".join(coordinate_names(self.ndim))),
@@ -228,7 +228,7 @@ class Rectilinear(_Base):
                 ("cf_role", "grid_topology"),
                 (
                     "long_name",
-                    "Topology data of {}D structured quadrilateral".format(self.ndim),
+                    f"Topology data of {self.ndim}D structured quadrilateral",
                 ),
                 ("topology_dimension", self.ndim),
                 ("node_coordinates", " ".join(coordinate_names(self.ndim))),
@@ -267,7 +267,7 @@ class UniformRectilinear(_Base):
                 ("cf_role", "grid_topology"),
                 (
                     "long_name",
-                    "Topology data of {}D structured quadrilateral".format(self.ndim),
+                    f"Topology data of {self.ndim}D structured quadrilateral",
                 ),
                 ("topology_dimension", self.ndim),
                 ("node_coordinates", " ".join(coordinate_names(self.ndim))),
@@ -314,6 +314,6 @@ def dataset_from_bmi_grid(bmi, grid_id):
     elif grid_type == "rectilinear":
         grid = Rectilinear(bmi, grid_id)
     else:
-        raise ValueError("grid type not understood ({gtype})".format(gtype=grid_type))
+        raise ValueError(f"grid type not understood ({grid_type})")
 
     return grid

--- a/pymt/framework/services.py
+++ b/pymt/framework/services.py
@@ -91,7 +91,7 @@ def register_component_class(name, if_exists="raise"):
         _COMPONENT_CLASSES[cls_name] = getattr(mod, cls_name)
     except (KeyError, AttributeError):
         raise ImportError(
-            "cannot import component %s from %s" % (cls_name, module_name)
+            "cannot import component {} from {}".format(cls_name, module_name)
         )
 
 

--- a/pymt/framework/timeinterp.py
+++ b/pymt/framework/timeinterp.py
@@ -93,7 +93,7 @@ class TimeInterpolator:
     @maxsize.setter
     def maxsize(self, val):
         if val is not None and val <= _MINIMUM_SIZE_FOR_METHOD[self.method]:
-            raise ValueError("maxsize too small for method ({0})".format(self.method))
+            raise ValueError(f"maxsize too small for method ({self.method})")
         self._maxsize = val
         self._trim_data_to_maxsize()
 

--- a/pymt/grids/field.py
+++ b/pymt/grids/field.py
@@ -1,6 +1,5 @@
 #! /bin/env python
 import numpy as np
-import six
 
 from .igrid import CENTERING_CHOICES, CenteringValueError, DimensionError, IField
 from .raster import UniformRectilinear
@@ -15,7 +14,7 @@ def combine_args_to_list(*args, **kwds):
     args = list(args)
     combined_args = []
     for arg in args:
-        if isinstance(arg, six.string_types):
+        if isinstance(arg, str):
             combined_args.append(arg)
         else:
             combined_args.extend(arg)

--- a/pymt/grids/igrid.py
+++ b/pymt/grids/igrid.py
@@ -22,7 +22,7 @@ class DimensionError(Error):
             self.dst_dim = dim1
 
     def __str__(self):
-        return "%s != %s" % (self.src_dim, self.dst_dim)
+        return "{} != {}".format(self.src_dim, self.dst_dim)
 
 
 class CenteringValueError(Error):

--- a/pymt/mappers/celltopoint.py
+++ b/pymt/mappers/celltopoint.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 from scipy.spatial import KDTree
-from six.moves import zip
 
 from .imapper import IGridMapper, IncompatibleGridError
 

--- a/pymt/mappers/imapper.py
+++ b/pymt/mappers/imapper.py
@@ -17,7 +17,7 @@ class IncompatibleGridError(MapperError):
         self._dst = dst
 
     def __str__(self):
-        return "Unable to map %s to %s" % (self._src, self._dst)
+        return "Unable to map {} to {}".format(self._src, self._dst)
 
 
 class NoMapperError(MapperError):
@@ -26,7 +26,7 @@ class NoMapperError(MapperError):
         self._dst = dst
 
     def __str__(self):
-        return "No mapper to map %s to %s" % (self._src, self._dst)
+        return "No mapper to map {} to {}".format(self._src, self._dst)
 
 
 class IGridMapper:

--- a/pymt/mappers/pointtocell.py
+++ b/pymt/mappers/pointtocell.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 
 import numpy as np
 from scipy.spatial import KDTree
-from six.moves import zip
 
 from .imapper import IGridMapper, IncompatibleGridError
 

--- a/pymt/portprinter/port_printer.py
+++ b/pymt/portprinter/port_printer.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
-
-import six
-from six.moves.configparser import ConfigParser
+from configparser import ConfigParser
+from io import StringIO
 
 from ..framework import services
 from ..printers.nc.database import Database as NcDatabase
@@ -21,7 +20,7 @@ class PortPrinter:
     _printer_class = None
 
     def __init__(self, port, var_name, filename=None):
-        if isinstance(port, six.string_types):
+        if isinstance(port, str):
             self._port = services.get_component_instance(port)
         else:
             self._port = port
@@ -62,7 +61,7 @@ class PortPrinter:
     @classmethod
     def from_string(cls, source, prefix="print"):
         config = ConfigParser()
-        config.readfp(six.StringIO(source))
+        config.readfp(StringIO(source))
         return cls._from_config(config, prefix=prefix)
 
     @classmethod

--- a/pymt/printers/nc/constants.py
+++ b/pymt/printers/nc/constants.py
@@ -4,7 +4,7 @@ import warnings
 
 from scipy.io import netcdf as nc3
 
-_VALID_NETCDF_FORMATS = set(["NETCDF3_CLASSIC", "NETCDF3_64BIT"])
+_VALID_NETCDF_FORMATS = {"NETCDF3_CLASSIC", "NETCDF3_64BIT"}
 
 _NP_TO_NC_TYPE = {
     "float32": "f4",
@@ -25,13 +25,13 @@ try:
 except ImportError:
     warnings.warn("Unable to import netCDF4.", ImportWarning)
 else:
-    _VALID_NETCDF_FORMATS |= set(["NETCDF4_CLASSIC", "NETCDF4"])
+    _VALID_NETCDF_FORMATS |= {"NETCDF4_CLASSIC", "NETCDF4"}
 
 
 def assert_valid_netcdf_format(fmt):
     if fmt not in _VALID_NETCDF_FORMATS:
         raise ValueError(
-            "%s: format is one of %s" % (fmt, ", ".join(_VALID_NETCDF_FORMATS))
+            "{}: format is one of {}".format(fmt, ", ".join(_VALID_NETCDF_FORMATS))
         )
 
 

--- a/pymt/printers/nc/database.py
+++ b/pymt/printers/nc/database.py
@@ -32,7 +32,7 @@ class Database(IDatabase):
 
         self._var_name = var_name
         self._path = path
-        self._template = "%s_%%04d%s" % (root, ext)
+        self._template = "{}_%04d{}".format(root, ext)
 
         self._point_count = None
         self._cell_count = None

--- a/pymt/printers/nc/ugrid_read.py
+++ b/pymt/printers/nc/ugrid_read.py
@@ -1,6 +1,4 @@
 #! /usr/bin/env python
-from six.moves import xrange
-
 from ...grids import RectilinearField, StructuredField, UnstructuredField
 from ...grids import utils as gutils
 from .constants import open_netcdf
@@ -65,7 +63,7 @@ class NetcdfFieldReader:
             "structured",
             "unstructured",
         ):
-            raise ValueError("topology not understood: {0}".format(topology.type))
+            raise ValueError(f"topology not understood: {topology.type}")
 
         return topology
 
@@ -74,7 +72,7 @@ class NetcdfFieldReader:
             if self._root.variables[name].location == "node":
                 data = self.variable_data(name)
                 if self.contains_time_dimension():
-                    for time in xrange(len(self.time)):
+                    for time in range(len(self.time)):
                         self._field.add_field(
                             name + "@t=%d" % time, data[time, :], centering="point"
                         )
@@ -87,7 +85,7 @@ class NetcdfFieldReader:
             if self._root.variables[name].location == "face":
                 data = self.variable_data(name)
                 if self.contains_time_dimension():
-                    for time in xrange(len(self.time)):
+                    for time in range(len(self.time)):
                         self._field.add_field(
                             name + "@t=%d" % time, data[time, :], centering="cell"
                         )

--- a/pymt/services/constant/constant.py
+++ b/pymt/services/constant/constant.py
@@ -14,7 +14,7 @@ class ConstantScalars:
         filename : str
             Name of initialization file.
         """
-        with open(filename, "r") as opened:
+        with open(filename) as opened:
             scalar_vars = yaml.safe_load(opened.read())
 
         self._vars = {}

--- a/pymt/services/gridreader/gridreader.py
+++ b/pymt/services/gridreader/gridreader.py
@@ -43,7 +43,7 @@ class TimeInterpolator:
     def update_until(self, time):
         if time < self._start_time or time > self._endtime:
             raise ValueError(
-                "time is outside of start/end time ({0} not in [{1}, {2}])".format(
+                "time is outside of start/end time ({} not in [{}, {}])".format(
                     time, self._start_time, self._end_time
                 )
             )

--- a/pymt/services/gridreader/time_series_names.py
+++ b/pymt/services/gridreader/time_series_names.py
@@ -1,7 +1,6 @@
 import collections
 import re
 
-import six
 
 _TIME_SERIES_NAME_RE_PATTERN = r"(?P<name>[a-zA-Z_]+)@t=(?P<time_stamp>\d+)$"
 _TIME_SERIES_NAME_RE = re.compile(_TIME_SERIES_NAME_RE_PATTERN)
@@ -28,12 +27,12 @@ class TimeStampError(Error):
 
 
 def time_stamp_as_string(time_stamp):
-    if isinstance(time_stamp, six.string_types):
+    if isinstance(time_stamp, str):
         try:
             return str(int(time_stamp))
         except ValueError:
             raise TimeStampError(time_stamp)
-    elif isinstance(time_stamp, six.integer_types):
+    elif isinstance(time_stamp, int):
         return str(time_stamp)
     else:
         raise TimeStampError(time_stamp)

--- a/pymt/utils/prefix.py
+++ b/pymt/utils/prefix.py
@@ -54,4 +54,4 @@ def strip_prefix(name, prefix):
     if name.startswith(prefix):
         return name[len(prefix) :]
     else:
-        raise ValueError("%s does not start with %s" % (name, prefix))
+        raise ValueError("{} does not start with {}".format(name, prefix))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
   "pyyaml",
   "scipy",
   "shapely",
-  "six",
   "xarray",
 ]
 dynamic = ["readme", "version"]

--- a/tests/component/test_model.py
+++ b/tests/component/test_model.py
@@ -41,7 +41,7 @@ def test_model_from_file_like(tmpdir, with_no_components):
         os.mkdir("air")
         with open("components.yml", "w") as fp:
             fp.write(AIR_PORT_CONTENTS)
-        with open("components.yml", "r") as fp:
+        with open("components.yml") as fp:
             model = Model.from_file_like(fp)
 
         assert model.components == ["air_port"]

--- a/tests/portprinter/test_nc_port_printer.py
+++ b/tests/portprinter/test_nc_port_printer.py
@@ -1,7 +1,5 @@
 import os
 
-from six.moves import xrange
-
 from pymt.portprinter.port_printer import NcPortPrinter
 from pymt.testing.ports import UniformRectilinearGridPort
 
@@ -27,7 +25,7 @@ def test_multiple_files(tmpdir):
 
     port = UniformRectilinearGridPort()
     with tmpdir.as_cwd():
-        for _ in xrange(5):
+        for _ in range(5):
             printer = NcPortPrinter(port, "sea_surface__temperature")
             printer.open()
             printer.write()
@@ -41,7 +39,7 @@ def test_time_series(tmpdir):
     with tmpdir.as_cwd():
         printer = NcPortPrinter(port, "sea_floor_surface_sediment__mean_of_grain_size")
         printer.open()
-        for _ in xrange(5):
+        for _ in range(5):
             printer.write()
         printer.close()
 

--- a/tests/printers/nc/test_nc.py
+++ b/tests/printers/nc/test_nc.py
@@ -23,7 +23,7 @@ def test_raster(tmpdir, ndims):
 
     field = RasterField(shape, spacing, origin, units=units)
 
-    attrs = {"description": "Example {ndims}D nc file".format(ndims=ndims)}
+    attrs = {"description": f"Example {ndims}D nc file"}
     data = np.arange(field.get_point_count())
 
     with tmpdir.as_cwd():
@@ -50,7 +50,7 @@ def test_rectilinear(tmpdir, ndims):
     data = np.arange(field.get_point_count())
     field.add_field("Elevation", data, centering="point")
 
-    attrs = dict(description="Example {0}D nc file".format(ndims), author="pytest")
+    attrs = dict(description=f"Example {ndims}D nc file", author="pytest")
 
     with tmpdir.as_cwd():
         field_tofile(field, "rectilinear.nc", attrs=attrs, append=True)

--- a/tests/printers/nc/test_ugrid.py
+++ b/tests/printers/nc/test_ugrid.py
@@ -17,7 +17,7 @@ def new_rectilinear(**kwds):
     shape = np.random.randint(3, 101 + 1, ndims)
     args = []
     for size in shape:
-        args.append(np.cumsum((1.0 - np.random.random(size))))
+        args.append(np.cumsum(1.0 - np.random.random(size)))
 
     return RectilinearField(*args, **kwds)
 

--- a/tests/services/gridreader/test_time_series_names.py
+++ b/tests/services/gridreader/test_time_series_names.py
@@ -46,7 +46,7 @@ def test_get_time_series_names():
             "earth_surface__temperature",
         ]
     )
-    assert names == set(["ice_surface__temperature"])
+    assert names == {"ice_surface__temperature"}
 
 
 def test_get_time_series_names_empty():
@@ -66,7 +66,7 @@ def test_get_time_series_names_ignore_bad_names():
             "sea_surface__temperature@t=",
         ]
     )
-    assert names == set(["ice_surface__temperature"])
+    assert names == {"ice_surface__temperature"}
 
 
 def test_sort_ascending_is_default():

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -19,7 +19,7 @@ def test_init_without_args():
 def test_init_with_one_event():
     timeline = Timeline([("event 1", 1.0)])
 
-    assert set(["event 1"]) == timeline.events
+    assert {"event 1"} == timeline.events
     assert 1.0 == timeline.time_of_next_event
     assert "event 1" == timeline.next_event
 
@@ -27,7 +27,7 @@ def test_init_with_one_event():
 def test_init_with_two_events():
     timeline = Timeline([("event 1", 1.0), ("event 2", 0.25)])
 
-    assert set(["event 1", "event 2"]) == timeline.events
+    assert {"event 1", "event 2"} == timeline.events
     assert timeline.time_of_next_event == approx(0.25)
     assert timeline.next_event == "event 2"
 


### PR DESCRIPTION
This pull request updates *pymt* to use Python 3.8+ syntax and, as a result, also remove usages of the *six* package.