### PR TITLE
Remove other uses of six dependency

### DIFF
--- a/deprecated/component_info.py
+++ b/deprecated/component_info.py
@@ -1,8 +1,7 @@
 #! /usr/bin/env python
 import collections
+import configparser
 
-import six
-from six.moves import configparser
 
 _KEY_TYPES = {
     "output_file_namespace": str,
@@ -27,7 +26,7 @@ class Error(Exception):
 
 class InfoKeyError(Error):
     def __init__(self, keys):
-        if isinstance(keys, six.string_types):
+        if isinstance(keys, str):
             self._keys = keys
         else:
             self._keys = ", ".join(keys)

--- a/deprecated/ordered_task_status.py
+++ b/deprecated/ordered_task_status.py
@@ -23,8 +23,6 @@ initialized
 
 """
 
-import six
-
 from pymt.task_status import TaskStatus
 
 
@@ -53,7 +51,7 @@ class OrderedTaskStatus:
             TaskStatus("finalize", started="finalizing", completed="finalized"),
         ]
 
-        if isinstance(current, six.string_types):
+        if isinstance(current, str):
             self._current = self.tasks.index(current)
         else:
             self._current = current

--- a/deprecated/portprinter/tests/test_bov_port_printer.py
+++ b/deprecated/portprinter/tests/test_bov_port_printer.py
@@ -1,5 +1,3 @@
-from six.moves import xrange
-
 from pymt.portprinter.port_printer import BovPortPrinter, PortPrinter
 from pymt.testing.ports import UniformRectilinearGridPort
 from pymt.testing.assertions import assert_isfile_and_remove
@@ -17,7 +15,7 @@ def test_default():
 
 def test_multiple_files():
     port = UniformRectilinearGridPort()
-    for _ in xrange(5):
+    for _ in range(5):
         printer = BovPortPrinter(port, "sea_surface__temperature")
         printer.open()
         printer.write()
@@ -43,7 +41,7 @@ def test_time_series():
     port = UniformRectilinearGridPort()
     printer = BovPortPrinter(port, "sea_floor_surface_sediment__mean_of_grain_size")
     printer.open()
-    for _ in xrange(5):
+    for _ in range(5):
         printer.write()
     printer.close()
 

--- a/deprecated/portprinter/tests/test_vtk_port_printer.py
+++ b/deprecated/portprinter/tests/test_vtk_port_printer.py
@@ -1,7 +1,5 @@
 import os
 
-from six.moves import xrange
-
 from pymt.portprinter.port_printer import VtkPortPrinter
 from pymt.testing.ports import UniformRectilinearGridPort
 
@@ -31,7 +29,7 @@ def test_time_series(tmpdir):
     with tmpdir.as_cwd():
         printer = VtkPortPrinter(port, "sea_floor_surface_sediment__mean_of_grain_size")
         printer.open()
-        for _ in xrange(5):
+        for _ in range(5):
             printer.write()
         printer.close()
 
@@ -43,7 +41,7 @@ def test_multiple_files(tmpdir):
     port = UniformRectilinearGridPort()
 
     with tmpdir.as_cwd():
-        for _ in xrange(5):
+        for _ in range(5):
             printer = VtkPortPrinter(port, "sea_surface__temperature")
             printer.open()
             printer.write()

--- a/deprecated/printers/vtk/vtkxml.py
+++ b/deprecated/printers/vtk/vtkxml.py
@@ -3,7 +3,6 @@ import sys
 import xml.dom.minidom
 
 import numpy as np
-from six.moves import xrange
 
 from .encoders import encode
 from .vtktypes import np_to_vtk_type, sys_to_vtk_endian
@@ -19,7 +18,7 @@ class VtkExtent:
         self._extent = []
         for n in shape:
             self._extent.append((0, n - 1))
-        for n in xrange(3 - len(shape)):
+        for n in range(3 - len(shape)):
             self._extent.append((0, 0))
 
         self._extent_str = " ".join(["%d %d" % x for x in self._extent])
@@ -42,7 +41,7 @@ class VtkOrigin:
         for (dx, x0) in zip(spacing, origin):
             self._cell_origin.append(x0 - dx * 0.5)
 
-        for _ in xrange(3 - len(origin)):
+        for _ in range(3 - len(origin)):
             self._cell_origin.append(0.0)
 
         self._origin_str = " ".join(["%f" % x for x in self._cell_origin])
@@ -61,7 +60,7 @@ class VtkSpacing:
         self._padded_spacing = []
         for dx in spacing:
             self._padded_spacing.append(dx)
-        for _ in xrange(3 - len(spacing)):
+        for _ in range(3 - len(spacing)):
             self._padded_spacing.append(0.0)
 
         self._spacing_str = " ".join(["%f" % x for x in self._padded_spacing])
@@ -172,7 +171,7 @@ class VtkPointsElement(VtkDataElement):
     def __init__(self, coords, **kwargs):
         n_components = 3
         xyz = []
-        for i in xrange(n_components):
+        for i in range(n_components):
             try:
                 xyz.append(coords[i])
             except IndexError:

--- a/deprecated/printers/vtk/vtu.py
+++ b/deprecated/printers/vtk/vtu.py
@@ -5,7 +5,6 @@ from collections import namedtuple
 from xml.etree.ElementTree import ElementTree
 
 import numpy as np
-from six.moves import xrange
 
 from ...grids import UnstructuredField
 from .vtk import (
@@ -250,7 +249,7 @@ def parse_points(points):
 
     n_points = len(data.data[0])
     components = data.data
-    for _ in xrange(3 - len(data.data)):
+    for _ in range(3 - len(data.data)):
         components.append(np.zeros(n_points))
 
     return Point(components[0], components[1], components[2])

--- a/deprecated/task_status.py
+++ b/deprecated/task_status.py
@@ -2,8 +2,6 @@
 
 from collections import OrderedDict
 
-import six
-
 _TASK_STATUS_STRINGS = OrderedDict(
     [
         ("create", ("creating", "created")),
@@ -53,7 +51,7 @@ def task_as_valid_integer(task):
 
 
 def task_as_integer(task):
-    if isinstance(task, six.string_types):
+    if isinstance(task, str):
         return task_string_as_integer(task)
     else:
         return task_as_valid_integer(task)

--- a/deprecated/test_component_info.py
+++ b/deprecated/test_component_info.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 import unittest
 import os
 import tempfile
-from six.moves.configparser import ConfigParser
+from configparser import ConfigParser
 
 from pymt.component_info import (
     ComponentInfo,

--- a/deprecated/tests/test_task_status.py
+++ b/deprecated/tests/test_task_status.py
@@ -1,8 +1,6 @@
 #! /usr/bin/env python
 import unittest
 
-from six.moves import xrange
-
 from pymt.task_status import TaskStatus
 
 
@@ -36,7 +34,7 @@ class TestTaskStatus(unittest.TestCase):
     def test_start_already_started(self):
         task = TaskStatus("task")
 
-        for _ in xrange(10):
+        for _ in range(10):
             task.start()
             self.assertEqual(task.status, task.started)
 

--- a/deprecated/utils/verbose.py
+++ b/deprecated/utils/verbose.py
@@ -4,15 +4,13 @@ import logging
 import os
 import sys
 
-from six import MAXSIZE
-
 _LEVEL_STRING = {"DEBUG": 10, "INFO": 20, "WARNING": 30, "ERROR": 40}
 _CMT_LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
 
 def log_level_string_to_int(level):
     if level.upper() in ["TRUE", "YES", "ON", "ENABLED"]:
-        verbosity = MAXSIZE
+        verbosity = sys.maxsize
     elif level.upper() in ["FALSE", "NO", "OFF", "DISABLED"]:
         verbosity = 0
     else:
@@ -105,7 +103,7 @@ class CmtVerbose(Verbose):
         if "CMT_VERBOSE" in os.environ:
             level = os.environ["CMT_VERBOSE"]
             if level.upper() in ["TRUE", "YES", "ON", "ENABLED"]:
-                verbosity = MAXSIZE
+                verbosity = sys.maxsize
             elif level.upper() in ["FALSE", "NO", "OFF", "DISABLED"]:
                 verbosity = 0
             else:

--- a/notebooks/child.ipynb
+++ b/notebooks/child.ipynb
@@ -156,7 +156,7 @@
       " |  >>> model = child()\n",
       " |  >>> (fname, initdir) = model.setup()\n",
       " |  >>> model.initialize(fname, dir=initdir)\n",
-      " |  >>> for _ in xrange(10):\n",
+      " |  >>> for _ in range(10):\n",
       " |  ...     model.update()\n",
       " |  >>> model.finalize()\n",
       " |  \n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ numpy
 pyyaml
 scipy
 shapely
-six
 xarray
 # cfunits
 # esmpy


### PR DESCRIPTION
This is a small follow-up on #159 to remove other uses of `six`.