### PR TITLE
Py source consistency using isort and pyupgrade tools, rm unused imports

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 #
 # pymt documentation build configuration file, created by
 # sphinx-quickstart on Fri Jun  9 13:47:02 2017.
@@ -24,7 +23,6 @@ import sys
 sys.path.insert(0, os.path.abspath(".."))
 
 import pymt
-
 
 if os.environ.get("READTHEDOCS", ""):
     # RTD doesn't use the repo's Makefile to build docs.
@@ -69,9 +67,9 @@ source_suffix = [".rst", ".ipynb"]
 master_doc = "index"
 
 # General information about the project.
-project = u"pymt"
-copyright = u"2018, Eric Hutton"
-author = u"Eric Hutton"
+project = "pymt"
+copyright = "2018, Eric Hutton"
+author = "Eric Hutton"
 
 # The version info for the project you're documenting, acts as replacement
 # for |version| and |release|, also used in various other places throughout
@@ -147,7 +145,7 @@ latex_elements = {
 # (source start file, target name, title, author, documentclass
 # [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "pymt.tex", u"pymt Documentation", u"Eric Hutton", "manual")
+    (master_doc, "pymt.tex", "pymt Documentation", "Eric Hutton", "manual")
 ]
 
 
@@ -155,7 +153,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "pymt", u"pymt Documentation", [author], 1)]
+man_pages = [(master_doc, "pymt", "pymt Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output ----------------------------------------
@@ -167,7 +165,7 @@ texinfo_documents = [
     (
         master_doc,
         "pymt",
-        u"pymt Documentation",
+        "pymt Documentation",
         author,
         "pymt",
         "One line description of project.",

--- a/docs/scripts/make_table.py
+++ b/docs/scripts/make_table.py
@@ -1,10 +1,10 @@
 #! /usr/bin/env python
 import os
 import textwrap
-from tabulate import tabulate
 
 import click
 import yaml
+from tabulate import tabulate
 
 
 def construct_rows(notebook_index=None):
@@ -20,7 +20,7 @@ def construct_rows(notebook_index=None):
                 [
                     summary,
                     "",
-                    "|binder-{0}|".format(name),
+                    f"|binder-{name}|",
                 ]
             )
         rows.append((name, summary))
@@ -59,12 +59,10 @@ def make_table(dest, notebook_index):
     footer = []
     for name, notebooks in index.items():
         footer.append(
+            f"""
+            .. |binder-{name}| image:: https://mybinder.org/badge_logo.svg
+                :target: https://mybinder.org/v2/gh/csdms/pymt.git/master?filepath=notebooks%2F{notebooks[0]}
             """
-            .. |binder-{0}| image:: https://mybinder.org/badge_logo.svg
-                :target: https://mybinder.org/v2/gh/csdms/pymt.git/master?filepath=notebooks%2F{1}
-            """.format(
-                name, notebooks[0]
-            )
         )
     print(textwrap.dedent(os.linesep.join(footer)), file=dest)
 

--- a/notebooks/conftest.py
+++ b/notebooks/conftest.py
@@ -2,16 +2,15 @@ import pathlib
 
 import pytest
 
-
 _TEST_DIR = pathlib.Path(__file__).absolute().parent
 
 
 def collect_notebooks(src):
     p = pathlib.Path(src)
     if p.is_dir():
-        return set([_p.absolute() for _p in iter_notebooks_in_dir(p, src)])
+        return {_p.absolute() for _p in iter_notebooks_in_dir(p, src)}
     else:
-        raise ValueError("{0}: not a directory".format(src))
+        raise ValueError(f"{src}: not a directory")
 
 
 def iter_notebooks_in_dir(path, root):

--- a/notebooks/test_notebooks.py
+++ b/notebooks/test_notebooks.py
@@ -6,8 +6,8 @@ import yaml
 
 _exclude_file = pathlib.Path(__file__).absolute().parent / "exclude.yml"
 if _exclude_file.exists():
-    with open(_exclude_file, "r") as fp:
-        _EXCLUDE = dict([(item["file"], item["reason"]) for item in yaml.safe_load(fp)])
+    with open(_exclude_file) as fp:
+        _EXCLUDE = {item["file"]: item["reason"] for item in yaml.safe_load(fp)}
 else:
     _EXCLUDE = {}
 

--- a/pymt/__init__.py
+++ b/pymt/__init__.py
@@ -1,6 +1,6 @@
-from ._version import __version__
-
 from gimli import UnitSystem
+
+from ._version import __version__
 from .model_collection import ModelCollection
 
 MODELS = ModelCollection()

--- a/pymt/errors.py
+++ b/pymt/errors.py
@@ -1,6 +1,3 @@
-#! /usr/bin/env python
-
-
 class PymtError(Exception):
 
     pass

--- a/pymt/framework/bmi_bridge.py
+++ b/pymt/framework/bmi_bridge.py
@@ -4,22 +4,21 @@ import json
 import os
 from pprint import pformat
 
+import gimli
 import numpy as np
 import yaml
-import gimli
 
 from deprecated import deprecated
 
-from ..utils import as_cwd
 from ..errors import BmiError
 from ..units import transform_azimuth_to_math, transform_math_to_azimuth
+from ..utils import as_cwd
 from .bmi_docstring import bmi_docstring
 from .bmi_mapper import GridMapperMixIn
 from .bmi_plot import quick_plot
 from .bmi_setup import SetupMixIn
 from .bmi_timeinterp import BmiTimeInterpolator
 from .bmi_ugrid import dataset_from_bmi_grid
-
 
 UNITS = gimli.units
 

--- a/pymt/framework/bmi_docstring.py
+++ b/pymt/framework/bmi_docstring.py
@@ -1,8 +1,6 @@
-#! /usr/bin/env python
 import jinja2
 from landlab.core.messages import format_message
 from model_metadata import MetadataNotFoundError, ModelMetadata
-
 
 # {{ desc|trim|wordwrap(70) if desc }}
 _DOCSTRING = """

--- a/pymt/framework/bmi_mapper.py
+++ b/pymt/framework/bmi_mapper.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 import warnings
 
 import numpy as np

--- a/pymt/framework/bmi_plot.py
+++ b/pymt/framework/bmi_plot.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/pymt/framework/bmi_setup.py
+++ b/pymt/framework/bmi_setup.py
@@ -1,13 +1,12 @@
-#! /usr/bin/env python
 import os
 import tempfile
 import urllib
 import zipfile
 
 import yaml
+from model_metadata import ModelMetadata
 from model_metadata.model_data_files import FileTemplate
 from model_metadata.model_setup import FileSystemLoader
-from model_metadata import ModelMetadata
 
 from ..utils import as_cwd
 

--- a/pymt/framework/bmi_timeinterp.py
+++ b/pymt/framework/bmi_timeinterp.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 from ..errors import BmiError
 from ..utils import as_cwd
 from .timeinterp import TimeInterpolator

--- a/pymt/framework/bmi_ugrid.py
+++ b/pymt/framework/bmi_ugrid.py
@@ -2,8 +2,7 @@ from collections import OrderedDict
 
 import numpy as np
 import xarray as xr
-
-from landlab.graph import StructuredQuadGraph, UniformRectilinearGraph, RectilinearGraph
+from landlab.graph import RectilinearGraph, StructuredQuadGraph, UniformRectilinearGraph
 
 COORDINATE_NAMES = ["z", "y", "x"]
 INDEX_NAMES = ["k", "j", "i"]

--- a/pymt/framework/services.py
+++ b/pymt/framework/services.py
@@ -90,9 +90,7 @@ def register_component_class(name, if_exists="raise"):
     try:
         _COMPONENT_CLASSES[cls_name] = getattr(mod, cls_name)
     except (KeyError, AttributeError):
-        raise ImportError(
-            "cannot import component {} from {}".format(cls_name, module_name)
-        )
+        raise ImportError(f"cannot import component {cls_name} from {module_name}")
 
 
 def register_component_instance(name, instance):

--- a/pymt/framework/timeinterp.py
+++ b/pymt/framework/timeinterp.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 import bisect
 
 from scipy.interpolate import interp1d

--- a/pymt/grids/assertions.py
+++ b/pymt/grids/assertions.py
@@ -1,6 +1,3 @@
-#! /usr/bin/env
-
-
 def is_callable_method(obj, method):
     return hasattr(obj, method) and callable(getattr(obj, method))
 

--- a/pymt/grids/connectivity.py
+++ b/pymt/grids/connectivity.py
@@ -1,5 +1,3 @@
-#! /bin/env python
-
 """
 >>> get_connectivity((6, ))
 array([0, 1, 1, 2, 2, 3, 3, 4, 4, 5])

--- a/pymt/grids/esmp.py
+++ b/pymt/grids/esmp.py
@@ -1,4 +1,3 @@
-#! /bin/env python
 """PyMT interface to ESMPy grids.
 
 **Examples**

--- a/pymt/grids/field.py
+++ b/pymt/grids/field.py
@@ -1,4 +1,3 @@
-#! /bin/env python
 import numpy as np
 
 from .igrid import CENTERING_CHOICES, CenteringValueError, DimensionError, IField

--- a/pymt/grids/igrid.py
+++ b/pymt/grids/igrid.py
@@ -22,7 +22,7 @@ class DimensionError(Error):
             self.dst_dim = dim1
 
     def __str__(self):
-        return "{} != {}".format(self.src_dim, self.dst_dim)
+        return f"{self.src_dim} != {self.dst_dim}"
 
 
 class CenteringValueError(Error):

--- a/pymt/grids/map.py
+++ b/pymt/grids/map.py
@@ -1,4 +1,3 @@
-#! /bin/env python
 """
 Examples
 ========

--- a/pymt/grids/raster.py
+++ b/pymt/grids/raster.py
@@ -1,4 +1,3 @@
-#! /bin/env python
 """
 Examples
 --------

--- a/pymt/grids/rectilinear.py
+++ b/pymt/grids/rectilinear.py
@@ -1,5 +1,3 @@
-#! /bin/env python
-
 """
 Examples
 --------

--- a/pymt/grids/structured.py
+++ b/pymt/grids/structured.py
@@ -1,5 +1,3 @@
-#! /bin/env python
-
 """
 Examples
 --------

--- a/pymt/grids/unstructured.py
+++ b/pymt/grids/unstructured.py
@@ -1,4 +1,3 @@
-#! /bin/env python
 import numpy as np
 
 from .igrid import IGrid

--- a/pymt/mappers/celltopoint.py
+++ b/pymt/mappers/celltopoint.py
@@ -1,5 +1,3 @@
-#! /bin/env python
-
 import numpy as np
 from scipy.spatial import KDTree
 

--- a/pymt/mappers/esmp.py
+++ b/pymt/mappers/esmp.py
@@ -1,5 +1,3 @@
-#! /bin/env python
-
 import numpy as np
 
 from ..grids.esmp import EsmpUnstructuredField

--- a/pymt/mappers/imapper.py
+++ b/pymt/mappers/imapper.py
@@ -1,6 +1,3 @@
-#! /bin/env python
-
-
 class MapperError(Exception):
     """Base class for error in this package."""
 
@@ -17,7 +14,7 @@ class IncompatibleGridError(MapperError):
         self._dst = dst
 
     def __str__(self):
-        return "Unable to map {} to {}".format(self._src, self._dst)
+        return f"Unable to map {self._src} to {self._dst}"
 
 
 class NoMapperError(MapperError):
@@ -26,7 +23,7 @@ class NoMapperError(MapperError):
         self._dst = dst
 
     def __str__(self):
-        return "No mapper to map {} to {}".format(self._src, self._dst)
+        return f"No mapper to map {self._src} to {self._dst}"
 
 
 class IGridMapper:

--- a/pymt/mappers/mapper.py
+++ b/pymt/mappers/mapper.py
@@ -1,4 +1,3 @@
-#! /bin/env python
 """
 Examples
 ========

--- a/pymt/mappers/pointtocell.py
+++ b/pymt/mappers/pointtocell.py
@@ -1,5 +1,3 @@
-#! /bin/env python
-
 from collections import defaultdict
 
 import numpy as np

--- a/pymt/mappers/pointtopoint.py
+++ b/pymt/mappers/pointtopoint.py
@@ -1,5 +1,3 @@
-#! /bin/env python
-
 import numpy as np
 from scipy.spatial import KDTree
 

--- a/pymt/model_collection.py
+++ b/pymt/model_collection.py
@@ -1,5 +1,6 @@
-import pkg_resources
 import traceback
+
+import pkg_resources
 
 from .framework.bmi_bridge import bmi_factory
 

--- a/pymt/portprinter/port_printer.py
+++ b/pymt/portprinter/port_printer.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 from configparser import ConfigParser
 from io import StringIO
 

--- a/pymt/printers/nc/constants.py
+++ b/pymt/printers/nc/constants.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 import os
 import warnings
 

--- a/pymt/printers/nc/database.py
+++ b/pymt/printers/nc/database.py
@@ -1,5 +1,3 @@
-#! /usr/bin/env python
-
 import os
 
 from .ugrid import close as ugrid_close
@@ -32,7 +30,7 @@ class Database(IDatabase):
 
         self._var_name = var_name
         self._path = path
-        self._template = "{}_%04d{}".format(root, ext)
+        self._template = f"{root}_%04d{ext}"
 
         self._point_count = None
         self._cell_count = None

--- a/pymt/printers/nc/read.py
+++ b/pymt/printers/nc/read.py
@@ -1,5 +1,3 @@
-#! /usr/bin/env python
-
 from pymt.grids.grid_type import (
     GridTypeRectilinear,
     GridTypeStructured,

--- a/pymt/printers/nc/ugrid.py
+++ b/pymt/printers/nc/ugrid.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 import os
 
 from ...grids import utils as gutils

--- a/pymt/printers/nc/ugrid_read.py
+++ b/pymt/printers/nc/ugrid_read.py
@@ -1,6 +1,9 @@
-#! /usr/bin/env python
-from ...grids import RectilinearField, StructuredField, UnstructuredField
-from ...grids import utils as gutils
+from ...grids import (
+    RectilinearField,
+    StructuredField,
+    UnstructuredField,
+    utils as gutils,
+)
 from .constants import open_netcdf
 
 

--- a/pymt/printers/nc/write.py
+++ b/pymt/printers/nc/write.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 from warnings import warn
 
 from ...grids.assertions import is_rectilinear, is_structured

--- a/pymt/services/constant/constant.py
+++ b/pymt/services/constant/constant.py
@@ -1,4 +1,3 @@
-#! /bin/env python
 import numpy as np
 import yaml
 

--- a/pymt/services/gridreader/gridreader.py
+++ b/pymt/services/gridreader/gridreader.py
@@ -1,4 +1,3 @@
-#! /bin/env python
 import warnings
 
 import yaml
@@ -95,6 +94,7 @@ class TimeInterpolator:
 
 def get_abspath_or_url(filename, prefix=""):
     import os
+
     from urlparse import urlparse, urlunparse
 
     parts = urlparse(filename)

--- a/pymt/services/gridreader/time_series_names.py
+++ b/pymt/services/gridreader/time_series_names.py
@@ -1,7 +1,6 @@
 import collections
 import re
 
-
 _TIME_SERIES_NAME_RE_PATTERN = r"(?P<name>[a-zA-Z_]+)@t=(?P<time_stamp>\d+)$"
 _TIME_SERIES_NAME_RE = re.compile(_TIME_SERIES_NAME_RE_PATTERN)
 

--- a/pymt/timeline.py
+++ b/pymt/timeline.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 """Execute events along a timeline.
 
 Examples

--- a/pymt/utils/__init__.py
+++ b/pymt/utils/__init__.py
@@ -1,4 +1,3 @@
 from .utils import as_cwd, err, out
 
-
 __all__ = ["as_cwd", "err", "out"]

--- a/pymt/utils/prefix.py
+++ b/pymt/utils/prefix.py
@@ -54,4 +54,4 @@ def strip_prefix(name, prefix):
     if name.startswith(prefix):
         return name[len(prefix) :]
     else:
-        raise ValueError("{} does not start with {}".format(name, prefix))
+        raise ValueError(f"{name} does not start with {prefix}")

--- a/pymt/utils/utils.py
+++ b/pymt/utils/utils.py
@@ -4,7 +4,6 @@ from functools import partial
 
 import click
 
-
 out = partial(click.secho, bold=True, err=True)
 err = partial(click.secho, fg="red", err=True)
 

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -1,16 +1,15 @@
 #! /usr/bin/env python
-from __future__ import print_function
 
 import os
 import re
 import subprocess
 import sys
 from collections import OrderedDict, defaultdict
-from pkg_resources import parse_version
 
 import click
 import jinja2
 import m2r
+from pkg_resources import parse_version
 
 __version__ = "0.1.1"
 
@@ -53,7 +52,7 @@ def git_log(start=None, stop="HEAD"):
         # '--oneline',
     ]
     if start:
-        cmd.append("{start}..{stop}".format(start=start, stop=stop))
+        cmd.append(f"{start}..{stop}")
     return subprocess.check_output(cmd).strip().decode("utf-8")
 
 
@@ -89,8 +88,8 @@ def releases(ascending=True):
 def format_pr_message(message):
     m = re.match(
         "Merge pull request (?P<pr>#[0-9]+) "
-        "from (?P<branch>[\S]*)"
-        "(?P<postscript>[\s\S]*$)",
+        r"from (?P<branch>[\S]*)"
+        r"(?P<postscript>[\s\S]*$)",
         message,
     )
     if m:
@@ -100,7 +99,7 @@ def format_pr_message(message):
 
 
 def format_changelog_message(message):
-    m = re.match("(?P<first>\w+)(?P<rest>[\s\S]*)$", message)
+    m = re.match(r"(?P<first>\w+)(?P<rest>[\s\S]*)$", message)
     word = m.groupdict()["first"]
     if word in ("Add", "Fix", "Deprecate"):
         return word + "ed" + m.groupdict()["rest"]
@@ -224,7 +223,7 @@ def main(output, quiet, verbose, format, force, batch):
     path_to_changelog = os.path.join(git_top_level(), "CHANGELOG." + format)
     if os.path.isfile(path_to_changelog) and not force:
         click.secho(
-            "{0} exists. Use --force to overwrite".format(path_to_changelog),
+            f"{path_to_changelog} exists. Use --force to overwrite",
             fg="red",
             err=True,
         )
@@ -233,7 +232,7 @@ def main(output, quiet, verbose, format, force, batch):
     with open(path_to_changelog, "w") as fp:
         fp.write(contents)
     click.secho(
-        "Fresh change log at {0}".format(path_to_changelog), bold=True, err=True
+        f"Fresh change log at {path_to_changelog}", bold=True, err=True
     )
 
 

--- a/scripts/prm2input.py
+++ b/scripts/prm2input.py
@@ -1,10 +1,6 @@
 #! /usr/bin/env python
 
-from __future__ import print_function
-
-import sys
-
-from cmt.scanners import InputParameterScanner, CmtScanner, MissingKeyError
+from cmt.scanners import InputParameterScanner
 
 
 def main():
@@ -16,13 +12,13 @@ def main():
     args = parser.parse_args()
 
     if len(args.file) == 1:
-        with open(args.file[0], "r") as f:
+        with open(args.file[0]) as f:
             scanner = InputParameterScanner(f)
             scanner.scan_file()
             print(scanner.fill_contents())
     else:
         for file in args.file:
-            with open(file, "r") as f:
+            with open(file) as f:
                 scanner = InputParameterScanner(f)
                 scanner.scan_file()
 

--- a/scripts/prm2template.py
+++ b/scripts/prm2template.py
@@ -1,10 +1,6 @@
 #! /usr/bin/env python
 
-from __future__ import print_function
-
-import sys
-
-from cmt.scanners import InputParameterScanner, CmtScanner, MissingKeyError
+from cmt.scanners import InputParameterScanner
 
 
 def main():
@@ -16,13 +12,13 @@ def main():
     args = parser.parse_args()
 
     if len(args.file) == 1:
-        with open(args.file[0], "r") as f:
+        with open(args.file[0]) as f:
             scanner = InputParameterScanner(f)
             scanner.scan_file()
             print(scanner.contents())
     else:
         for file in args.file:
-            with open(file, "r") as f:
+            with open(file) as f:
                 scanner = InputParameterScanner(f)
                 scanner.scan_file()
 

--- a/scripts/prmscan.py
+++ b/scripts/prmscan.py
@@ -1,10 +1,6 @@
 #! /usr/bin/env python
 
-from __future__ import print_function
-
-import sys
-
-from cmt.scanners import InputParameterScanner, CmtScanner, MissingKeyError
+from cmt.scanners import CmtScanner, InputParameterScanner
 
 
 def main():

--- a/scripts/vtu2ncu.py
+++ b/scripts/vtu2ncu.py
@@ -1,10 +1,9 @@
 #! /usr/bin/env python
 
-import os
 import argparse
 
-import cmt.vtk
 import cmt.nc
+import cmt.vtk
 
 parser = argparse.ArgumentParser(description="Convert VTK file to NCU files")
 parser.add_argument("files", metavar="vtk_file", nargs="+", help="VTK formatted file")

--- a/tests/component/__init__.py
+++ b/tests/component/__init__.py
@@ -1,5 +1,5 @@
 def setup():
-    from pymt.framework.services import register_component_classes, del_services
+    from pymt.framework.services import del_services, register_component_classes
 
     del_services()
 

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.fixture(scope="session")
 def with_no_components():
-    from pymt.framework.services import register_component_classes, del_services
+    from pymt.framework.services import del_services, register_component_classes
 
     del_services()
 

--- a/tests/events/conftest.py
+++ b/tests/events/conftest.py
@@ -4,9 +4,9 @@ import pytest
 @pytest.fixture(scope="session")
 def with_earth_and_air():
     from pymt.framework.services import (
-        register_component_classes,
-        instantiate_component,
         del_services,
+        instantiate_component,
+        register_component_classes,
     )
 
     del_services()

--- a/tests/framework/test_bmi_var_units.py
+++ b/tests/framework/test_bmi_var_units.py
@@ -1,6 +1,5 @@
-import pytest
-
 import numpy as np
+import pytest
 from gimli import IncompatibleUnitsError, UnitNameError
 from numpy.testing import assert_array_equal
 

--- a/tests/grids/test_assertions.py
+++ b/tests/grids/test_assertions.py
@@ -1,5 +1,3 @@
-#! /usr/bin/env python
-
 import unittest
 
 from pymt.grids import (

--- a/tests/grids/test_esmp.py
+++ b/tests/grids/test_esmp.py
@@ -1,5 +1,3 @@
-#! /usr/bin/env python import unittest
-
 import numpy as np
 import pytest
 from pytest import approx

--- a/tests/grids/test_field.py
+++ b/tests/grids/test_field.py
@@ -1,5 +1,3 @@
-#! /usr/bin/env python
-
 import unittest
 
 import numpy as np

--- a/tests/grids/test_raster.py
+++ b/tests/grids/test_raster.py
@@ -1,5 +1,3 @@
-#! /usr/bin/env python
-
 import unittest
 
 import numpy as np

--- a/tests/grids/test_rectilinear.py
+++ b/tests/grids/test_rectilinear.py
@@ -1,5 +1,3 @@
-#! /usr/bin/env python
-
 import unittest
 
 import numpy as np

--- a/tests/mappers/test_mapper.py
+++ b/tests/mappers/test_mapper.py
@@ -1,10 +1,10 @@
-#! /usr/bin/env python
-
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from pymt.grids.map import UniformRectilinearMap as UniformRectilinear
-from pymt.grids.map import UnstructuredPointsMap as UnstructuredPoints
+from pymt.grids.map import (
+    UniformRectilinearMap as UniformRectilinear,
+    UnstructuredPointsMap as UnstructuredPoints,
+)
 from pymt.mappers import CellToPoint, PointToCell
 
 

--- a/tests/mappers/test_pointtopoint.py
+++ b/tests/mappers/test_pointtopoint.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal

--- a/tests/portprinter/__init__.py
+++ b/tests/portprinter/__init__.py
@@ -1,8 +1,8 @@
 def setup():
     from pymt.framework.services import (
-        register_component_classes,
-        instantiate_component,
         del_services,
+        instantiate_component,
+        register_component_classes,
     )
 
     del_services()

--- a/tests/portprinter/conftest.py
+++ b/tests/portprinter/conftest.py
@@ -4,9 +4,9 @@ import pytest
 @pytest.fixture(scope="function")
 def with_two_components():
     from pymt.framework.services import (
-        register_component_classes,
-        instantiate_component,
         del_services,
+        instantiate_component,
+        register_component_classes,
     )
 
     del_services()

--- a/tests/portprinter/test_port_printer_queue.py
+++ b/tests/portprinter/test_port_printer_queue.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 import os
 
 import xarray

--- a/tests/portprinter/test_utils.py
+++ b/tests/portprinter/test_utils.py
@@ -1,6 +1,3 @@
-#! /usr/bin/env python
-
-
 import unittest
 
 import numpy as np

--- a/tests/printers/nc/test_database.py
+++ b/tests/printers/nc/test_database.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 import os
 
 import numpy as np

--- a/tests/printers/nc/test_nc.py
+++ b/tests/printers/nc/test_nc.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 import os
 
 import numpy as np

--- a/tests/printers/nc/test_nc_examples.py
+++ b/tests/printers/nc/test_nc_examples.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 import os
 
 import numpy as np

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 import os
 
 import pytest

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 import pytest
 from pytest import approx
 

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -3,11 +3,10 @@ import random
 
 import numpy as np
 import pytest
-from gimli import IncompatibleUnitsError, UnitNameError, UnitStatus, UnitFormatting
-from pymt.units import transform_azimuth_to_math, transform_math_to_azimuth
-
+from gimli import IncompatibleUnitsError, UnitFormatting, UnitNameError, UnitStatus
 
 from pymt import UnitSystem
+from pymt.units import transform_azimuth_to_math, transform_math_to_azimuth
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR is further clean-up, mostly automated with a few manual edits. Using [isort](https://github.com/PyCQA/isort), [pyupgrade](https://github.com/asottile/pyupgrade), also `flake8 --select F401` to identify unused imports.

Also remove unused shebangs on non-executable module and test files.