### PR TITLE
Fix docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,24 +1,18 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 sphinx:
   builder: html
   configuration: docs/conf.py
   fail_on_warning: false
 
-formats:
-  - htmlzip
-
 python:
-  version: 3.8
   install:
     - requirements: requirements-docs.txt
     - requirements: requirements.txt
     - method: pip
       path: .
-  system_packages: false
-
-conda:
-  environment: environment-docs.yml
-
-build:
-  image: latest

--- a/README.rst
+++ b/README.rst
@@ -77,14 +77,10 @@ The Community Surface Dynamics Modeling System (CSDMS)*.
 .. |Documentation Status| image:: https://readthedocs.org/projects/pymt/badge/?version=latest
    :target: https://pymt.readthedocs.io/en/latest/?badge=latest
 .. |Coverage Status| image:: https://coveralls.io/repos/github/csdms/pymt/badge.svg?branch=master
+   :target: https://coveralls.io/github/csdms/pymt?branch=master
 .. |Conda Version| image:: https://anaconda.org/conda-forge/pymt/badges/version.svg
    :target: https://anaconda.org/conda-forge/pymt
-   :target: https://conda.anaconda.org/conda-forge
 .. |Conda Downloads| image:: https://anaconda.org/conda-forge/pymt/badges/downloads.svg
    :target: https://anaconda.org/conda-forge/pymt
 .. |Binder| image:: https://static.mybinder.org/badge_logo.svg
    :target: https://static.mybinder.org/badge_logo.svg
-
-
-
-

--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,6 @@ The Community Surface Dynamics Modeling System (CSDMS)*.
 .. |Documentation Status| image:: https://readthedocs.org/projects/pymt/badge/?version=latest
    :target: https://pymt.readthedocs.io/en/latest/?badge=latest
 .. |Coverage Status| image:: https://coveralls.io/repos/github/csdms/pymt/badge.svg?branch=master
-   :target: https://coveralls.io/github/csdms/pymt?branch=master
 .. |Conda Version| image:: https://anaconda.org/conda-forge/pymt/badges/version.svg
    :target: https://anaconda.org/conda-forge/pymt
    :target: https://conda.anaconda.org/conda-forge

--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,8 @@
 The Python Modeling Toolkit (pymt)
 ==================================
 
-|Build Status| |License| |Code Style| |Documentation Status| |Coverage Status| |Conda Version|
-|Conda Installation| |Conda Downloads| |Binder|
+|Build Status| |License| |Code Style| |Documentation Status| |Coverage Status|
+|Conda Version| |Conda Downloads| |Binder|
 
 Quick links:
 
@@ -80,7 +80,6 @@ The Community Surface Dynamics Modeling System (CSDMS)*.
    :target: https://coveralls.io/github/csdms/pymt?branch=master
 .. |Conda Version| image:: https://anaconda.org/conda-forge/pymt/badges/version.svg
    :target: https://anaconda.org/conda-forge/pymt
-.. |Conda Installation| image:: https://anaconda.org/conda-forge/pymt/badges/installer/conda.svg
    :target: https://conda.anaconda.org/conda-forge
 .. |Conda Downloads| image:: https://anaconda.org/conda-forge/pymt/badges/downloads.svg
    :target: https://anaconda.org/conda-forge/pymt


### PR DESCRIPTION
This PR updates the rtfd configuration file so the docs [build](https://pymt.readthedocs.io/en/mdpiper-fix-docs-build/) on readthedocs.io.
